### PR TITLE
AN-1822/caps for comment

### DIFF
--- a/models/core/core__dim_contract_labels.yml
+++ b/models/core/core__dim_contract_labels.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:
@@ -12,7 +11,7 @@ models:
             - contract_name
 
     columns:
-      - name: event_contract
+      - name: EVENT_CONTRACT
         description: "{{ doc('event_contract') }}"
         tests:
           - not_null
@@ -21,7 +20,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: contract_name
+      - name: CONTRACT_NAME
         description: "{{ doc('contract_name') }}"
         tests:
           - not_null
@@ -30,7 +29,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: account_address
+      - name: ACCOUNT_ADDRESS
         description: "{{ doc('account_address') }}"
         tests:
           - not_null

--- a/models/core/core__dim_topshot_metadata.sql
+++ b/models/core/core__dim_topshot_metadata.sql
@@ -5,7 +5,24 @@
 WITH topshot AS (
 
     SELECT
-        *
+        nft_id,
+        nft_collection,
+        nbatopshot_id,
+        serial_number,
+        total_circulation,
+        moment_description,
+        player,
+        team,
+        season,
+        play_category,
+        play_type,
+        moment_date,
+        set_name,
+        set_series_number,
+        video_urls,
+        moment_stats_full,
+        player_stats_game,
+        player_stats_season_to_date,
     FROM
         {{ ref('silver__nft_topshot_metadata') }}
 )

--- a/models/core/core__dim_topshot_metadata.sql
+++ b/models/core/core__dim_topshot_metadata.sql
@@ -22,7 +22,7 @@ WITH topshot AS (
         video_urls,
         moment_stats_full,
         player_stats_game,
-        player_stats_season_to_date,
+        player_stats_season_to_date
     FROM
         {{ ref('silver__nft_topshot_metadata') }}
 )

--- a/models/core/core__dim_topshot_metadata.yml
+++ b/models/core/core__dim_topshot_metadata.yml
@@ -10,7 +10,7 @@ models:
             - nft_id
 
     columns:
-      - name: nft_id
+      - name: NFT_ID
         description: "{{ doc('nft_id') }}"
         tests:
           - not_null
@@ -20,7 +20,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: nft_collection
+      - name: NFT_COLLECTION
         description: "{{ doc('nft_collection') }}"
         tests:
           - not_null
@@ -29,7 +29,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: nbatopshot_id
+      - name: NBATOPSHOT_ID
         description: "{{ doc('nbatopshot_id') }}"
         tests:
           - not_null
@@ -38,7 +38,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: serial_number
+      - name: SERIAL_NUMBER
         description: "{{ doc('serial_number') }}"
         tests:
           - not_null
@@ -46,7 +46,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: total_circulation
+      - name: TOTAL_CIRCULATION
         description: "{{ doc('total_circulation') }}"
         tests:
           - not_null
@@ -54,7 +54,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: moment_description
+      - name: MOMENT_DESCRIPTION
         description: "{{ doc('moment_description') }}"
         tests:
           - not_null
@@ -63,7 +63,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: player
+      - name: PLAYER
         description: "{{ doc('player') }}"
         tests:
           - not_null
@@ -72,7 +72,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: team
+      - name: TEAM
         description: "{{ doc('team') }}"
         tests:
           - not_null
@@ -81,7 +81,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: season
+      - name: SEASON
         description: "{{ doc('season') }}"
         tests:
           - not_null
@@ -90,7 +90,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: play_category
+      - name: PLAY_CATEGORY
         description: "{{ doc('play_category') }}"
         tests:
           - not_null
@@ -99,7 +99,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: play_type
+      - name: PLAY_TYPE
         description: "{{ doc('play_type') }}"
         tests:
           - not_null
@@ -108,7 +108,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: moment_date
+      - name: MOMENT_DATE
         description: "{{ doc('moment_date') }}"
         tests:
           - not_null
@@ -116,7 +116,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: set_name
+      - name: SET_NAME
         description: "{{ doc('set_name') }}"
         tests:
           - not_null
@@ -125,7 +125,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: set_series_number
+      - name: SET_SERIES_NUMBER
         description: "{{ doc('set_series_number') }}"
         tests:
           - not_null
@@ -133,7 +133,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: video_urls
+      - name: VIDEO_URLS
         description: "{{ doc('video_urls') }}"
         tests:
           - not_null
@@ -141,7 +141,7 @@ models:
               column_type_list:
                 - ARRAY
 
-      - name: moment_stats_full
+      - name: MOMENT_STATS_FULL
         description: "{{ doc('moment_stats_full') }}"
         tests:
           - not_null
@@ -150,7 +150,7 @@ models:
                 - OBJECT
                 - VARIANT
 
-      - name: player_stats_game
+      - name: PLAYER_STATS_GAME
         description: "{{ doc('player_stats_game') }}"
         tests:
           - not_null
@@ -159,7 +159,7 @@ models:
                 - OBJECT
                 - VARIANT
 
-      - name: player_stats_season_to_date
+      - name: PLAYER_STATS_SEASON_TO_DATE
         description: "{{ doc('player_stats_season_to_date') }}"
         tests:
           - not_null
@@ -167,11 +167,3 @@ models:
               column_type_list:
                 - OBJECT
                 - VARIANT
-
-      - name: _inserted_timestamp
-        description: "{{ doc('_inserted_timestamp') }}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - TIMESTAMP_NTZ

--- a/models/core/core__dim_validator_labels.yml
+++ b/models/core/core__dim_validator_labels.yml
@@ -1,17 +1,16 @@
-
 version: 2
 
 models:
   - name: core__dim_validator_labels
     description: |-
-      This table stores all of the Validator Node IDs and the type of validator, per id. 
+      This table stores all of the Validator Node IDs and the type of validator, per id.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - node_id
 
     columns:
-      - name: node_id
+      - name: NODE_ID
         description: "{{ doc('node_id') }}"
         tests:
           - not_null
@@ -21,7 +20,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: validator_type
+      - name: VALIDATOR_TYPE
         description: "{{ doc('validator_type') }}"
         tests:
           - not_null
@@ -30,7 +29,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: project_name
+      - name: PROJECT_NAME
         description: "{{ doc('project_name') }}"
         tests:
           - not_null

--- a/models/core/core__fact_blocks.yml
+++ b/models/core/core__fact_blocks.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:
@@ -10,7 +9,7 @@ models:
           where: BLOCK_TIMESTAMP < CURRENT_DATE
 
     columns:
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
@@ -20,7 +19,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: block_timestamp
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -31,7 +30,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: network
+      - name: NETWORK
         description: "{{ doc('network') }}"
         tests:
           - not_null
@@ -40,7 +39,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: chain_id
+      - name: CHAIN_ID
         description: "{{ doc('chain_id') }}"
         tests:
           - not_null
@@ -49,7 +48,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: tx_count
+      - name: TX_COUNT
         description: "{{ doc('tx_count') }}"
         tests:
           - not_null
@@ -57,7 +56,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: id
+      - name: ID
         description: "{{ doc('id') }}"
         tests:
           - not_null
@@ -66,7 +65,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: parent_id
+      - name: PARENT_ID
         description: "{{ doc('parent_id') }}"
         tests:
           - not_null

--- a/models/core/core__fact_bridge_transactions.yml
+++ b/models/core/core__fact_bridge_transactions.yml
@@ -10,12 +10,12 @@ models:
             - tx_id
 
     columns:
-      - name: tx_id
+      - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
 
-      - name: block_timestamp
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -26,7 +26,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
@@ -35,7 +35,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: bridge_contract
+      - name: BRIDGE_CONTRACT
         description: "{{ doc('bridge_contract') }}"
         tests:
           - not_null
@@ -44,7 +44,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: token_contract
+      - name: TOKEN_CONTRACT
         description: "{{ doc('token_contract') }}"
         tests:
           - not_null
@@ -53,7 +53,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: amount
+      - name: AMOUNT
         description: "{{ doc('amount') }}"
         tests:
           - not_null
@@ -63,7 +63,7 @@ models:
                 - DOUBLE
                 - FLOAT
 
-      - name: flow_wallet_address
+      - name: FLOW_WALLET_ADDRESS
         description: "{{ doc('flow_wallet_address') }}"
         tests:
           - not_null
@@ -72,7 +72,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: blockchain
+      - name: BLOCKCHAIN
         description: "{{ doc('blockchain') }}"
         tests:
           - not_null
@@ -81,7 +81,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: direction
+      - name: DIRECTION
         description: "{{ doc('direction') }}"
         tests:
           - not_null
@@ -90,7 +90,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: bridge
+      - name: BRIDGE
         description: "{{ doc('bridge') }}"
         tests:
           - not_null

--- a/models/core/core__fact_events.yml
+++ b/models/core/core__fact_events.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:
@@ -12,12 +11,12 @@ models:
             - event_index
 
     columns:
-      - name: tx_id
+      - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
 
-      - name: block_timestamp
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -28,7 +27,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
@@ -37,7 +36,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: tx_succeeded
+      - name: TX_SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
           - not_null
@@ -45,7 +44,7 @@ models:
               column_type_list:
                 - BOOLEAN
 
-      - name: event_index
+      - name: EVENT_INDEX
         description: "{{ doc('event_index') }}"
         tests:
           - not_null
@@ -53,7 +52,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: event_contract
+      - name: EVENT_CONTRACT
         description: "{{ doc('event_contract') }}"
         tests:
           - not_null
@@ -62,7 +61,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: event_type
+      - name: EVENT_TYPE
         description: "{{ doc('event_type') }}"
         tests:
           - not_null
@@ -71,7 +70,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: event_data
+      - name: EVENT_DATA
         description: "{{ doc('event_attributes') }}"
         tests:
           - not_null

--- a/models/core/core__fact_nft_sales.yml
+++ b/models/core/core__fact_nft_sales.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:
@@ -11,7 +10,7 @@ models:
             - tx_id
 
     columns:
-      - name: tx_id
+      - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
@@ -21,16 +20,16 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-                - NUMBER    
-                - FLOAT  
+                - NUMBER
+                - FLOAT
 
-      - name: block_timestamp
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -41,7 +40,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: marketplace
+      - name: MARKETPLACE
         description: "{{ doc('marketplace') }}"
         tests:
           - not_null
@@ -50,7 +49,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: nft_collection
+      - name: NFT_COLLECTION
         description: "{{ doc('nft_collection') }}"
         tests:
           - not_null
@@ -59,7 +58,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: nft_id
+      - name: NFT_ID
         description: "{{ doc('nft_id') }}"
         tests:
           - not_null
@@ -69,7 +68,7 @@ models:
                 - VARCHAR
                 - NUMBER
 
-      - name: buyer
+      - name: BUYER
         description: "{{ doc('buyer') }}"
         tests:
           - not_null
@@ -78,7 +77,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: seller
+      - name: SELLER
         description: "{{ doc('seller') }}"
         tests:
           - not_null
@@ -87,7 +86,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: price
+      - name: PRICE
         description: "{{ doc('price') }}"
         tests:
           - not_null
@@ -96,7 +95,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: currency
+      - name: CURRENCY
         description: "{{ doc('currency') }}"
         tests:
           - not_null
@@ -105,7 +104,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: tx_succeeded
+      - name: TX_SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
           - not_null
@@ -113,7 +112,7 @@ models:
               column_type_list:
                 - BOOLEAN
 
-      - name: tokenflow
+      - name: TOKENFLOW
         description: "{{ doc('tokenflow') }}"
         tests:
           - not_null
@@ -123,7 +122,7 @@ models:
                 - OBJECT
                 - VARIANT
 
-      - name: counterparties
+      - name: COUNTERPARTIES
         description: "{{ doc('counterparties') }}"
         tests:
           - not_null

--- a/models/core/core__fact_prices.yml
+++ b/models/core/core__fact_prices.yml
@@ -6,7 +6,7 @@ models:
       This table provides token price data for FLOW tokens.
 
     columns:
-      - name: timestamp
+      - name: TIMESTAMP
         description: "{{ doc('timestamp') }}"
         tests:
           - not_null
@@ -14,7 +14,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: token
+      - name: TOKEN
         description: "{{ doc('token') }}"
         tests:
           - not_null
@@ -23,7 +23,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: symbol
+      - name: SYMBOL
         description: "{{ doc('symbol') }}"
         tests:
           - not_null
@@ -32,7 +32,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: token_contract
+      - name: TOKEN_CONTRACT
         description: "{{ doc('token_contract') }}"
         tests:
           - not_null
@@ -41,7 +41,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: price_usd
+      - name: PRICE_USD
         description: "{{ doc('price_usd') }}"
         tests:
           - not_null
@@ -51,7 +51,7 @@ models:
                 - DOUBLE
                 - FLOAT
 
-      - name: source
+      - name: SOURCE
         description: "{{ doc('source') }}"
         tests:
           - not_null

--- a/models/core/core__fact_swaps.yml
+++ b/models/core/core__fact_swaps.yml
@@ -10,12 +10,12 @@ models:
             - tx_id
 
     columns:
-      - name: tx_id
+      - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
 
-      - name: block_timestamp
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -26,7 +26,7 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
@@ -35,7 +35,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: swap_contract
+      - name: SWAP_CONTRACT
         description: "{{ doc('swap_contract') }}"
         tests:
           - not_null
@@ -44,7 +44,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: trader
+      - name: TRADER
         description: "{{ doc('trader') }}"
         tests:
           - not_null
@@ -53,7 +53,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: token_out_amount
+      - name: TOKEN_OUT_AMOUNT
         description: "{{ doc('token_out_amount') }}"
         tests:
           - not_null
@@ -62,7 +62,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: token_out_contract
+      - name: TOKEN_OUT_CONTRACT
         description: "{{ doc('token_out_contract') }}"
         tests:
           - not_null
@@ -71,7 +71,7 @@ models:
                 - STRING
                 - VARCHAR
 
-      - name: token_in_amount
+      - name: TOKEN_IN_AMOUNT
         description: "{{ doc('token_in_amount') }}"
         tests:
           - not_null
@@ -80,7 +80,7 @@ models:
                 - NUMBER
                 - FLOAT
 
-      - name: token_in_contract
+      - name: TOKEN_IN_CONTRACT
         description: "{{ doc('token_in_contract') }}"
         tests:
           - not_null

--- a/models/core/core__fact_transactions.yml
+++ b/models/core/core__fact_transactions.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:
@@ -12,7 +11,7 @@ models:
             - block_height
 
     columns:
-      - name: tx_id
+      - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests:
           - not_null
@@ -21,8 +20,8 @@ models:
               column_block: block_height
               column_tx_count: tx_count
               where: BLOCK_TIMESTAMP < CURRENT_DATE
-              
-      - name: block_timestamp
+
+      - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
           - not_null
@@ -33,51 +32,51 @@ models:
               column_type_list:
                 - TIMESTAMP_NTZ
 
-      - name: block_height
+      - name: BLOCK_HEIGHT
         description: "{{ doc('block_height') }}"
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-                - NUMBER    
-                - FLOAT  
+                - NUMBER
+                - FLOAT
 
-      - name: chain_id
+      - name: CHAIN_ID
         description: "{{ doc('chain_id') }}"
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-              - STRING
-              - VARCHAR
+                - STRING
+                - VARCHAR
 
-      - name: tx_index
+      - name: TX_INDEX
         description: tbd
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-                - NUMBER    
+                - NUMBER
 
-      - name: proposer
+      - name: PROPOSER
         description: "{{ doc('proposer') }}"
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-              - STRING
-              - VARCHAR
+                - STRING
+                - VARCHAR
 
-      - name: payer
+      - name: PAYER
         description: "{{ doc('payer') }}"
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-              - STRING
-              - VARCHAR
+                - STRING
+                - VARCHAR
 
-      - name: authorizers
+      - name: AUTHORIZERS
         description: "{{ doc('authorizers') }}"
         tests:
           - not_null
@@ -85,7 +84,7 @@ models:
               column_type_list:
                 - ARRAY
 
-      - name: count_authorizers
+      - name: COUNT_AUTHORIZERS
         description: "{{ doc('count_authorizers') }}"
         tests:
           - not_null
@@ -93,7 +92,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: gas_limit
+      - name: GAS_LIMIT
         description: "{{ doc('gas_limit') }}"
         tests:
           - not_null
@@ -101,7 +100,7 @@ models:
               column_type_list:
                 - NUMBER
 
-      - name: transaction_result
+      - name: TRANSACTION_RESULT
         description: "{{ doc('transaction_result') }}"
         tests:
           - not_null
@@ -109,7 +108,7 @@ models:
               column_type_list:
                 - VARIANT
 
-      - name: tx_succeeded
+      - name: TX_SUCCEEDED
         description: "{{ doc('tx_succeeded') }}"
         tests:
           - not_null
@@ -117,7 +116,7 @@ models:
               column_type_list:
                 - BOOLEAN
 
-      - name: error_msg
+      - name: ERROR_MSG
         description: tbd
         tests:
           - not_null


### PR DESCRIPTION
1. capitalizes the column name in the `yml` so snowflake runs `COMMENT`
2. explicitly lists column names for the topshot metadata (to drop `_inserted_timestamp`)