### PR TITLE
AN-1830/topshot nft ids

### DIFF
--- a/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
+++ b/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
@@ -35,7 +35,7 @@ all_topshots AS (
         sales
 )
 SELECT
-    *
+    DISTINCT *
 FROM
     all_topshots
 EXCEPT

--- a/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
+++ b/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
@@ -3,14 +3,41 @@
     post_hook = 'call silver.sp_bulk_get_topshot_moments_minted_metadata()'
 ) }}
 
+WITH mints AS (
+
+    SELECT
+        event_contract,
+        event_data :momentID :: STRING AS moment_id
+    FROM
+        {{ ref('silver__events_final') }}
+    WHERE
+        event_contract = 'A.0b2a3299cc857e29.TopShot'
+        AND event_type = 'MomentMinted'
+),
+sales AS (
+    SELECT
+        nft_collection AS event_contract,
+        nft_id AS moment_id
+    FROM
+        {{ ref('silver__nft_sales') }}
+    WHERE
+        nft_collection ILIKE '%topshot%'
+),
+all_topshots AS (
+    SELECT
+        *
+    FROM
+        mints
+    UNION
+    SELECT
+        *
+    FROM
+        sales
+)
 SELECT
-    event_contract,
-    event_data :momentID :: STRING AS moment_id
+    *
 FROM
-    {{ ref('silver__events_final') }}
-WHERE
-    event_contract = 'A.0b2a3299cc857e29.TopShot'
-    AND event_type = 'MomentMinted'
+    all_topshots
 EXCEPT
 SELECT
     contract,

--- a/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
+++ b/models/silver/silver__all_topshot_moments_minted_metadata_needed.sql
@@ -25,12 +25,14 @@ sales AS (
 ),
 all_topshots AS (
     SELECT
-        *
+        event_contract,
+        moment_id
     FROM
         mints
     UNION
     SELECT
-        *
+        event_contract,
+        moment_id
     FROM
         sales
 )


### PR DESCRIPTION
This adds TopShot `nft_ids` from nft sales to the metadata job, where previously we were only pulling new mints.