### PR TITLE
AN-1837/events fix

### DIFF
--- a/models/core/core__fact_prices.sql
+++ b/models/core/core__fact_prices.sql
@@ -5,7 +5,9 @@
 WITH token_labels AS (
 
     SELECT
-        *
+        token,
+        UPPER(symbol) AS symbol,
+        token_contract
     FROM
         {{ ref('seeds__token_labels') }}
 ),
@@ -13,7 +15,7 @@ prices AS (
     SELECT
         recorded_at AS TIMESTAMP,
         token,
-        symbol,
+        UPPER(symbol) AS symbol,
         price_usd,
         source
     FROM

--- a/models/silver/silver__event_attributes.sql
+++ b/models/silver/silver__event_attributes.sql
@@ -11,15 +11,16 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events') }}
+    WHERE
+        _inserted_timestamp :: DATE < '2022-07-18'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 events_data AS (

--- a/models/silver/silver__event_attributes_https.sql
+++ b/models/silver/silver__event_attributes_https.sql
@@ -1,0 +1,101 @@
+{{ config(
+    materialized = 'incremental',
+    cluster_by = ['_inserted_timestamp::DATE'],
+    unique_key = 'attribute_id',
+    incremental_strategy = 'delete+insert'
+) }}
+
+WITH events AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__events') }}
+    WHERE
+        _inserted_timestamp :: DATE >= '2022-07-18'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+events_data AS (
+    SELECT
+        event_id,
+        tx_id,
+        block_timestamp,
+        event_index,
+        event_contract,
+        event_type,
+        _event_data_type,
+        _event_data_fields,
+        _ingested_at,
+        COALESCE(
+            _event_data_type :fields,
+            _event_data_type :Fields
+        ) AS event_data_type_fields,
+        _inserted_timestamp
+    FROM
+        events
+),
+attributes AS (
+    SELECT
+        event_id,
+        tx_id,
+        block_timestamp,
+        event_index,
+        event_contract,
+        event_type,
+        COALESCE(
+            VALUE :identifier,
+            VALUE :Identifier
+        ) :: STRING AS attribute_key,
+        COALESCE(
+            _event_data_fields [index] :fields,
+            _event_data_fields [index] :staticType :typeID,
+            _event_data_fields [index] :value :value,
+            _event_data_fields [index] :value,
+            _event_data_fields [index] :Value,
+            _event_data_fields [index]
+        ) :: STRING AS attribute_value,
+        concat_ws(
+            '-',
+            event_id,
+            INDEX
+        ) AS attribute_id,
+        INDEX AS attribute_index,
+        _ingested_at,
+        _inserted_timestamp
+    FROM
+        events_data,
+        LATERAL FLATTEN(
+            input => event_data_type_fields
+        )
+),
+FINAL AS (
+    SELECT
+        attribute_id,
+        event_id,
+        tx_id,
+        block_timestamp,
+        event_index,
+        attribute_index,
+        event_contract,
+        event_type,
+        attribute_key,
+        attribute_value,
+        _ingested_at,
+        _inserted_timestamp
+    FROM
+        attributes
+    WHERE
+        attribute_key IS NOT NULL
+)
+SELECT
+    *
+FROM
+    FINAL


### PR DESCRIPTION
Splits event handling before and after 7/18 to account for the move from gRPC to HTTPS.
On test failures:
- NFT issues documented in AN-1866 and will fix
- Bridge model issues documented in AN-1865 and will fix
- Sequence gaps should be filling with the latest Vertex update & I will get block heights to Paul for rewalking to get the event data from 7/18 to 8/5.