### PR TITLE
AN-1988/events handle

### DIFF
--- a/models/silver/silver__event_attributes_https.sql
+++ b/models/silver/silver__event_attributes_https.sql
@@ -98,6 +98,9 @@ attributes_2 AS (
         event_type,
         VALUE :name :: STRING AS attribute_key,
         COALESCE(
+            VALUE :value :value :fields,
+            VALUE :value :value :staticType,
+            VALUE :value :value :value :value,
             VALUE :value :value :value,
             VALUE :value :value
         ) AS attribute_value,

--- a/models/silver/silver__event_attributes_https.sql
+++ b/models/silver/silver__event_attributes_https.sql
@@ -141,7 +141,7 @@ FINAL AS (
         _inserted_timestamp,
         _cte
     FROM
-        attributes
+        combo
 )
 SELECT
     *

--- a/models/silver/silver__event_attributes_https.sql
+++ b/models/silver/silver__event_attributes_https.sql
@@ -23,6 +23,17 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
+event_nulls AS (
+    SELECT
+        *
+    FROM
+        events
+    WHERE
+        COALESCE (
+            _event_data_type :Fields,
+            _event_data_type :fields
+        ) IS NULL
+),
 events_data AS (
     SELECT
         event_id,
@@ -69,12 +80,50 @@ attributes AS (
         ) AS attribute_id,
         INDEX AS attribute_index,
         _ingested_at,
-        _inserted_timestamp
+        _inserted_timestamp,
+        'attributes' AS _cte
     FROM
         events_data,
         LATERAL FLATTEN(
             input => event_data_type_fields
         )
+),
+attributes_2 AS (
+    SELECT
+        event_id,
+        tx_id,
+        block_timestamp,
+        event_index,
+        event_contract,
+        event_type,
+        VALUE :name :: STRING AS attribute_key,
+        COALESCE(
+            VALUE :value :value :value,
+            VALUE :value :value
+        ) AS attribute_value,
+        concat_ws(
+            '-',
+            event_id,
+            INDEX
+        ) AS attribute_id,
+        INDEX AS attribute_index,
+        _ingested_at,
+        _inserted_timestamp,
+        'attributes_2' AS _cte
+    FROM
+        event_nulls,
+        LATERAL FLATTEN(_event_data_fields)
+),
+combo AS (
+    SELECT
+        *
+    FROM
+        attributes
+    UNION
+    SELECT
+        *
+    FROM
+        attributes_2
 ),
 FINAL AS (
     SELECT
@@ -89,11 +138,10 @@ FINAL AS (
         attribute_key,
         attribute_value,
         _ingested_at,
-        _inserted_timestamp
+        _inserted_timestamp,
+        _cte
     FROM
         attributes
-    WHERE
-        attribute_key IS NOT NULL
 )
 SELECT
     *


### PR DESCRIPTION
Fixes missing event data 
Some known failures as ticketed [here](https://team-1612274056224.atlassian.net/browse/AN-1945?atlOrigin=eyJpIjoiNmYwOWY1MDMxZjI0NGI3M2I0NjkxYTJlMTY0NTAxZDIiLCJwIjoiaiJ9).

reminder - need to do a full refresh on _both_ event attribute models, everything downstream of them.
 - for ad hoc run: `dbt run -s silver__event_attributes+ silver__event_attributes_https+ --full-refresh`
