### PR TITLE
AN-2161/events location

### DIFF
--- a/models/bronze/bronze__blocks.sql
+++ b/models/bronze/bronze__blocks.sql
@@ -18,3 +18,5 @@ FROM
         'prod',
         'flow_blocks'
     ) }}
+WHERE
+    _inserted_timestamp :: DATE >= '2022-05-01'

--- a/models/bronze/bronze__transactions.sql
+++ b/models/bronze/bronze__transactions.sql
@@ -19,3 +19,5 @@ FROM
     'prod',
     'flow_txs'
   ) }}
+WHERE
+  _inserted_timestamp :: DATE >= '2022-05-01'

--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -33,7 +33,11 @@ events AS (
       VALUE :eventIndex
     ) :: NUMBER AS event_index,
     SPLIT(
-      VALUE :type,
+      IFF(
+        VALUE :type = 'Event',
+        VALUE :qualifiedIdentifier,
+        VALUE :type
+      ),
       '.'
     ) AS type_split,
     ARRAY_TO_STRING(

--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -35,7 +35,7 @@ events AS (
     SPLIT(
       IFF(
         VALUE :type = 'Event',
-        VALUE :qualifiedIdentifier,
+        VALUE :eventType :qualifiedIdentifier,
         VALUE :type
       ),
       '.'

--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -33,8 +33,7 @@ events AS (
       VALUE :eventIndex
     ) :: NUMBER AS event_index,
     SPLIT(
-      IFF(
-        VALUE :type = 'Event',
+      COALESCE(
         VALUE :eventType :qualifiedIdentifier,
         VALUE :type
       ),


### PR DESCRIPTION
New bloxy structure has the event contract and type in `qualifiedIdentifier` and `type` is now just the string "Events" and as we are backfilling a huge number of blocks, we are losing a lot of good data in the live models with the incremental strategy.

A refresh is going to take a _long_ time, so I suggest compiling the SQL and running the model in Snowflake, looking for where event contract is either an empty string `''` or where event type is `Event` (the current 2 issues this is solving)