### PR TITLE
AN-2178/events fix

### DIFF
--- a/models/core/core__ez_bridge_transactions.sql
+++ b/models/core/core__ez_bridge_transactions.sql
@@ -49,5 +49,3 @@ SELECT
     *
 FROM
     combo
-WHERE
-    block_timestamp >= '2022-04-20'

--- a/models/core/core__ez_dex_swaps.sql
+++ b/models/core/core__ez_dex_swaps.sql
@@ -17,8 +17,6 @@ WITH single_swaps AS (
         token_in_contract
     FROM
         {{ ref('silver__swaps_single_trade') }}
-    WHERE
-        block_timestamp >= '2022-04-20'
 )
 SELECT
     *

--- a/models/core/core__ez_nft_sales.sql
+++ b/models/core/core__ez_nft_sales.sql
@@ -9,8 +9,6 @@ WITH silver_nfts AS (
         *
     FROM
         {{ ref('silver__nft_sales') }}
-    WHERE
-        block_timestamp >= '2022-04-20'
 ),
 gold_nfts AS (
     SELECT

--- a/models/core/core__ez_staking_actions.sql
+++ b/models/core/core__ez_staking_actions.sql
@@ -9,8 +9,6 @@ WITH staking_actions AS (
         *
     FROM
         {{ ref('silver__staking_actions') }}
-    WHERE
-        block_timestamp :: DATE >= '2022-04-20'
 ),
 FINAL AS (
     SELECT

--- a/models/core/core__ez_token_transfers.sql
+++ b/models/core/core__ez_token_transfers.sql
@@ -14,9 +14,3 @@ SELECT
     tx_succeeded
 FROM
     {{ ref('silver__token_transfers') }}
-WHERE
-    block_timestamp :: DATE >= '2022-04-20'
-    AND (
-        token_contract = 'A.c38aea683c0c4d38.ZelosAccountingToken'
-        AND recipient IS NOT NULL
-    )

--- a/models/core/core__ez_token_transfers.sql
+++ b/models/core/core__ez_token_transfers.sql
@@ -14,3 +14,5 @@ SELECT
     tx_succeeded
 FROM
     {{ ref('silver__token_transfers') }}
+WHERE
+    token_contract != 'A.c38aea683c0c4d38.ZelosAccountingToken'

--- a/models/core/core__fact_blocks.sql
+++ b/models/core/core__fact_blocks.sql
@@ -8,8 +8,6 @@ WITH silver_blocks AS (
         *
     FROM
         {{ ref('silver__blocks') }}
-    WHERE
-        block_timestamp >= '2022-04-20'
 ),
 gold_blocks AS (
     SELECT

--- a/models/core/core__fact_events.sql
+++ b/models/core/core__fact_events.sql
@@ -8,8 +8,6 @@ WITH events_final AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        block_timestamp >= '2022-04-20'
 ),
 events AS (
     SELECT

--- a/models/core/core__fact_transactions.sql
+++ b/models/core/core__fact_transactions.sql
@@ -8,8 +8,6 @@ WITH silver_txs AS (
         *
     FROM
         {{ ref('silver__transactions') }}
-    WHERE
-        block_timestamp >= '2022-04-20'
 ),
 gold_txs AS (
     SELECT

--- a/models/core/core__fact_transactions.yml
+++ b/models/core/core__fact_transactions.yml
@@ -79,7 +79,6 @@ models:
       - name: AUTHORIZERS
         description: "{{ doc('authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -87,7 +86,6 @@ models:
       - name: COUNT_AUTHORIZERS
         description: "{{ doc('count_authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/silver/silver__bad_events.sql
+++ b/models/silver/silver__bad_events.sql
@@ -1,0 +1,29 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    cluster_by = ['_inserted_timestamp::date'],
+    unique_key = "CONCAT_WS('-', tx_id, event_index)"
+) }}
+
+WITH events AS (
+
+    SELECT
+        *
+    FROM
+        {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING = '{}'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    *
+FROM
+    events

--- a/models/silver/silver__bad_events.yml
+++ b/models/silver/silver__bad_events.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: silver__bad_events
+    description: Tracks erroneous events.
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          max_value: 1

--- a/models/silver/silver__bridge_blocto.sql
+++ b/models/silver/silver__bridge_blocto.sql
@@ -12,15 +12,16 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 teleport_events AS (

--- a/models/silver/silver__bridge_blocto.sql
+++ b/models/silver/silver__bridge_blocto.sql
@@ -12,16 +12,17 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 teleport_events AS (

--- a/models/silver/silver__bridge_celer.sql
+++ b/models/silver/silver__bridge_celer.sql
@@ -12,15 +12,16 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 cbridge_txs AS (

--- a/models/silver/silver__bridge_celer.sql
+++ b/models/silver/silver__bridge_celer.sql
@@ -12,16 +12,17 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 cbridge_txs AS (

--- a/models/silver/silver__events.sql
+++ b/models/silver/silver__events.sql
@@ -62,6 +62,7 @@ events AS (
         tx_id,
         event_index
       ) AS event_id,
+      TRY_PARSE_JSON(BASE64_DECODE_STRING(VALUE :payload)) AS try_parse_payload,
       _ingested_at,
       _inserted_timestamp
       FROM
@@ -85,6 +86,7 @@ events AS (
         event_data,
         event_data_type AS _event_data_type,
         event_data_fields AS _event_data_fields,
+        try_parse_payload AS _try_parse_payload,
         _ingested_at,
         _inserted_timestamp
       FROM

--- a/models/silver/silver__events_final.sql
+++ b/models/silver/silver__events_final.sql
@@ -92,7 +92,11 @@ objs AS (
         event_id,
         OBJECT_AGG(
             attribute_key,
-            attribute_value :: variant
+            IFF(
+                attribute_value IS NULL,
+                'null',
+                attribute_value
+            ) :: variant
         ) AS event_data
     FROM
         all_event_attributes

--- a/models/silver/silver__nft_sales.yml
+++ b/models/silver/silver__nft_sales.yml
@@ -95,6 +95,8 @@ models:
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER
+                - DOUBLE
+                - FLOAT
 
       - name: currency
         description: "{{ doc('currency') }}"

--- a/models/silver/silver__nft_topshot_sales.sql
+++ b/models/silver/silver__nft_topshot_sales.sql
@@ -12,15 +12,16 @@ WITH silver_events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 moment_data AS (

--- a/models/silver/silver__nft_topshot_sales.sql
+++ b/models/silver/silver__nft_topshot_sales.sql
@@ -12,16 +12,17 @@ WITH silver_events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 moment_data AS (

--- a/models/silver/silver__nft_topshot_sales.yml
+++ b/models/silver/silver__nft_topshot_sales.yml
@@ -4,12 +4,6 @@ models:
   - name: silver__nft_topshot_sales
     description: |-
       TopShot direct market sales on the Flow blockchain.
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - tx_id
-            - buyer
-            - nft_id
 
     columns:
       - name: tx_id

--- a/models/silver/silver__nft_transactions_secondary_market.sql
+++ b/models/silver/silver__nft_transactions_secondary_market.sql
@@ -12,16 +12,17 @@ WITH silver_events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 sale_trigger AS (

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -21,7 +21,10 @@ prices AS (
     SELECT
         recorded_at,
         asset_id,
-        NAME AS token,
+        COALESCE(
+            NAME,
+            INITCAP(SPLIT(asset_id, '-') [0])
+        ) AS token,
         SPLIT(
             symbol,
             '$'
@@ -41,7 +44,15 @@ adj_token_names AS (
             WHEN token = 'Blocto Token' THEN 'Blocto'
             ELSE token
         END AS token,
-        symbol,
+        COALESCE(
+            symbol,
+            CASE
+                WHEN token = 'Flow' THEN 'FLOW'
+                WHEN token = 'Blocto' THEN 'BLT'
+                WHEN token = 'Starly' THEN 'STARLY'
+                ELSE 'Error'
+            END
+        ) AS symbol,
         price,
         source
     FROM

--- a/models/silver/silver__staking_actions.sql
+++ b/models/silver/silver__staking_actions.sql
@@ -11,16 +11,17 @@ WITH silver_events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 flow_staking AS (

--- a/models/silver/silver__staking_actions.sql
+++ b/models/silver/silver__staking_actions.sql
@@ -11,15 +11,16 @@ WITH silver_events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 flow_staking AS (

--- a/models/silver/silver__swaps_events.sql
+++ b/models/silver/silver__swaps_events.sql
@@ -20,7 +20,8 @@ swaps_txs AS (
   FROM
     {{ ref('silver__events_final') }}
   WHERE
-    event_contract IN (
+    event_data :: STRING != '{}'
+    AND event_contract IN (
       SELECT
         event_contract
       FROM
@@ -42,7 +43,8 @@ swap_events AS (
   FROM
     {{ ref('silver__events_final') }}
   WHERE
-    tx_id IN (
+    event_data :: STRING != '{}'
+    AND tx_id IN (
       SELECT
         tx_id
       FROM

--- a/models/silver/silver__swaps_events.sql
+++ b/models/silver/silver__swaps_events.sql
@@ -43,13 +43,13 @@ swap_events AS (
   FROM
     {{ ref('silver__events_final') }}
   WHERE
-    event_data :: STRING != '{}'
-    AND tx_id IN (
+    tx_id IN (
       SELECT
         tx_id
       FROM
         swaps_txs
     )
+    AND event_data :: STRING != '{}'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/silver__token_transfers.sql
+++ b/models/silver/silver__token_transfers.sql
@@ -11,16 +11,17 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
-    WHERE
-        event_data :: STRING != '{}'
+        -- WHERE
+        --     event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp)
-    FROM
-        {{ this }}
-)
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp)
+        FROM
+            {{ this }}
+    )
 {% endif %}
 ),
 transfers AS (

--- a/models/silver/silver__token_transfers.sql
+++ b/models/silver/silver__token_transfers.sql
@@ -11,15 +11,16 @@ WITH events AS (
         *
     FROM
         {{ ref('silver__events_final') }}
+    WHERE
+        event_data :: STRING != '{}'
 
 {% if is_incremental() %}
-WHERE
-    _inserted_timestamp >= (
-        SELECT
-            MAX(_inserted_timestamp)
-        FROM
-            {{ this }}
-    )
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp)
+    FROM
+        {{ this }}
+)
 {% endif %}
 ),
 transfers AS (

--- a/models/silver/silver__transactions.yml
+++ b/models/silver/silver__transactions.yml
@@ -75,7 +75,6 @@ models:
       - name: authorizers
         description: "{{ doc('authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -83,7 +82,6 @@ models:
       - name: count_authorizers
         description: "{{ doc('count_authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER

--- a/models/silver/silver__transactions_blocto.yml
+++ b/models/silver/silver__transactions_blocto.yml
@@ -75,7 +75,6 @@ models:
       - name: authorizers
         description: "{{ doc('authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - ARRAY
@@ -83,7 +82,6 @@ models:
       - name: count_authorizers
         description: "{{ doc('count_authorizers') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - NUMBER


### PR DESCRIPTION
This closes the bug ticket by re-working the events model to take data from the decoded `payload` where it does not exist elsewhere in the data.
Known failures:
- there are 5 transactions that need to be re-walked as the `tx` object is null
- 235 missing blocks
- 60k missing transactions

I have a list of the blocks we need to re-walk to close out these errors and am ticketing for PL.

This PR also closes:
- AN-2166 by removing the data filter on core and releases the full chain to velocity
- AN-2169 checking the data by spork