### PR TITLE
bespoke tests

### DIFF
--- a/tests/tests__moment_metadata_allday.sql
+++ b/tests/tests__moment_metadata_allday.sql
@@ -1,0 +1,16 @@
+WITH moments AS (
+    SELECT
+        nft_collection,
+        nft_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__nft_allday_metadata') }}
+    WHERE
+        _inserted_timestamp :: DATE >= CURRENT_DATE - 1
+)
+SELECT
+    IFF(COUNT(nft_id) > 0, TRUE, FALSE) AS recent
+FROM
+    moments
+HAVING
+    recent = FALSE

--- a/tests/tests__moment_metadata_topshot.sql
+++ b/tests/tests__moment_metadata_topshot.sql
@@ -1,0 +1,16 @@
+WITH moments AS (
+    SELECT
+        nft_collection,
+        nft_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__nft_topshot_metadata') }}
+    WHERE
+        _inserted_timestamp :: DATE >= CURRENT_DATE - 1
+)
+SELECT
+    IFF(COUNT(nft_id) > 0, TRUE, FALSE) AS recent
+FROM
+    moments
+HAVING
+    recent = FALSE


### PR DESCRIPTION
Adds freshness tests for AllDay and TopShot metadata ingest, will fail if the data is > 1 day old.
Note - the lambda has not run in dev in a while so will fail. Test on prod:
`dbt test -s tests/tests__moment_metadata_allday.sql -t prod`
`dbt test -s tests/tests__moment_metadata_topshot.sql -t prod`

AllDay should alert, TopShot should pass.