### PR TITLE
Block order test

### DIFF
--- a/tests/tests__block_timestamp_order.sql
+++ b/tests/tests__block_timestamp_order.sql
@@ -1,3 +1,7 @@
+{{ config(
+    severity = "error"
+) }}
+
 SELECT
     DATEDIFF(
         SECOND,

--- a/tests/tests__block_timestamp_order.sql
+++ b/tests/tests__block_timestamp_order.sql
@@ -1,0 +1,16 @@
+SELECT
+    DATEDIFF(
+        SECOND,
+        A.block_timestamp,
+        b.block_timestamp
+    ) AS avg_time_diff,
+    b.block_height AS bheight,
+    b.block_timestamp AS btime,
+    A.*
+FROM
+    {{ ref('silver__blocks') }} A,
+    {{ ref('silver__blocks') }}
+    b
+WHERE
+    A.block_height = b.block_height -1
+    AND avg_time_diff < 0


### PR DESCRIPTION
Quickfix to add a custom test to ensure blocks are in order, as expected.

Run with:
`dbt test -s tests__block_timestamp_order`