### PR TITLE
An 2569/only retry req 3 times

### DIFF
--- a/models/bronze/bronze__moments_metadata.sql
+++ b/models/bronze/bronze__moments_metadata.sql
@@ -7,6 +7,7 @@ SELECT
     contract,
     DATA,
     VALUE,
+    _inserted_date,
     TO_TIMESTAMP_NTZ(SUBSTR(SPLIT_PART(metadata$filename, '/', 4), 1, 10) :: NUMBER, 0) AS _inserted_timestamp
 FROM
     {{ source(

--- a/models/streamline/streamline__all_topshot_moments_minted_metadata_needed.sql
+++ b/models/streamline/streamline__all_topshot_moments_minted_metadata_needed.sql
@@ -34,14 +34,37 @@ all_topshots AS (
         moment_id
     FROM
         sales
+),
+always_null AS (
+    SELECT
+        id,
+        contract,
+        COUNT(*) AS num_times_null_resp
+    FROM
+        {{ ref('streamline__null_moments_metadata') }}
+    WHERE
+        contract = 'A.0b2a3299cc857e29.TopShot'
+    GROUP BY
+        1,
+        2
+    HAVING
+        num_times_null_resp > 2
 )
 SELECT
     DISTINCT *
 FROM
     all_topshots
 EXCEPT
-SELECT
-    nft_collection as event_contract,
-    nft_id AS moment_id
-FROM
-    {{ ref('silver__nft_topshot_metadata') }}
+    (
+        SELECT
+            nft_collection AS event_contract,
+            nft_id AS moment_id
+        FROM
+            {{ ref('silver__nft_topshot_metadata') }}
+        UNION
+        SELECT
+            contract,
+            id
+        FROM
+            always_null
+    )

--- a/models/streamline/streamline__null_moments_metadata.sql
+++ b/models/streamline/streamline__null_moments_metadata.sql
@@ -25,7 +25,7 @@ AND _inserted_date >= (
 )
 AND _inserted_timestamp > (
     SELECT
-        MAX(_inserted_date)
+        MAX(_inserted_timestamp)
     FROM
         {{ this }}
 )

--- a/models/streamline/streamline__null_moments_metadata.sql
+++ b/models/streamline/streamline__null_moments_metadata.sql
@@ -7,12 +7,9 @@ SELECT
     id,
     contract,
     _inserted_date,
-    TO_TIMESTAMP_NTZ(SUBSTR(SPLIT_PART(metadata$filename, '/', 4), 1, 10) :: NUMBER, 0) AS _inserted_timestamp
+    _inserted_timestamp
 FROM
-    {{ source(
-        'bronze_streamline',
-        'moments_minted_metadata_api'
-    ) }}
+    {{ ref('bronze__moments_metadata') }}
 WHERE
     DATA :getMintedMoment :: STRING IS NULL
 

--- a/models/streamline/streamline__null_moments_metadata.sql
+++ b/models/streamline/streamline__null_moments_metadata.sql
@@ -1,0 +1,34 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = ["id","contract","_inserted_date"]
+) }}
+
+SELECT
+    id,
+    contract,
+    _inserted_date,
+    TO_TIMESTAMP_NTZ(SUBSTR(SPLIT_PART(metadata$filename, '/', 4), 1, 10) :: NUMBER, 0) AS _inserted_timestamp
+FROM
+    {{ source(
+        'bronze_streamline',
+        'moments_minted_metadata_api'
+    ) }}
+WHERE
+    DATA :getMintedMoment :: STRING IS NULL
+
+{% if is_incremental() %}
+AND _inserted_date >= (
+    SELECT
+        MAX(_inserted_date)
+    FROM
+        {{ this }}
+)
+AND _inserted_timestamp > (
+    SELECT
+        MAX(_inserted_date)
+    FROM
+        {{ this }}
+)
+{% else %}
+AND _inserted_date >= '2022-12-09'
+{% endif %}


### PR DESCRIPTION
- New model to index every time (from 12/9 forward) we receive null metadata from a moment 
- Use model to ignore those ids when triggering streamline for metadata when it has been tried 3x