### PR TITLE
Stream 97 blocks assembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 # set default target
 DBT_TARGET ?= sbx
+AWS_LAMBDA_ROLE ?= aws_lambda_flow_api_sbx
 
 dbt-console: 
 	docker-compose run dbt_console
@@ -26,6 +27,6 @@ grant-streamline-privileges:
 	--profile flow \
 	--target $(DBT_TARGET) \
 	--profiles-dir ~/.dbt/ \
-	--args '{role: aws_lambda_flow_api}'
+	--args '{role: $(AWS_LAMBDA_ROLE)}'
 
 undo_clone_purge: sl-flow-api udfs grant-streamline-privileges

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,12 @@ udfs:
 	--profile flow \
 	--target $(DBT_TARGET) \
 	--profiles-dir ~/.dbt/
+
+grant-streamline-privileges:
+	dbt run-operation grant_streamline_privileges \
+	--profile flow \
+	--target $(DBT_TARGET) \
+	--profiles-dir ~/.dbt/ \
+	--args '{role: aws_lambda_flow_api}'
+
+undo_clone_purge: sl-flow-api udfs grant-streamline-privileges

--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -94,8 +94,8 @@
     {{ result_var }}
 {% endmacro %}
 
--- macro used to select priveleges on all views/tables in a target chema to a role
-{% macro grant_select(role) %}
+-- macro used to grant streamline priveleges to a role
+{% macro grant_streamline_privileges(role) %}
     {{ log("Granting privileges to role: " ~ role, info=True) }}
     {% set sql %}
         grant usage on schema {{ target.schema }} to role {{ role }};

--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -98,9 +98,11 @@
 {% macro grant_streamline_privileges(role) %}
     {{ log("Granting privileges to role: " ~ role, info=True) }}
     {% set sql %}
+        grant usage on database {{ target.database }} to role {{ role }};
         grant usage on schema {{ target.schema }} to role {{ role }};
         grant select on all tables in schema {{ target.schema }} to role {{ role }};
         grant select on all views in schema {{ target.schema }} to role {{ role }};
+        -- AWS_LAMBDA_FLOW_API_SBX does not have access to these items: database FLOW_DEV, schema FLOW_DEV.STREAMLINE.
     {% endset %}
 
     {% do run_query(sql) %}

--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -102,7 +102,6 @@
         grant usage on schema {{ target.schema }} to role {{ role }};
         grant select on all tables in schema {{ target.schema }} to role {{ role }};
         grant select on all views in schema {{ target.schema }} to role {{ role }};
-        -- AWS_LAMBDA_FLOW_API_SBX does not have access to these items: database FLOW_DEV, schema FLOW_DEV.STREAMLINE.
     {% endset %}
 
     {% do run_query(sql) %}

--- a/models/silver/streamline/core/history/streamline__get_blocks_history.sql
+++ b/models/silver/streamline/core/history/streamline__get_blocks_history.sql
@@ -22,7 +22,7 @@ SELECT
     PARSE_JSON(
         CONCAT(
             '{"grpc": "proto3",',
-            '"method": "get_block_by_height',
+            '"method": "get_block_by_height",',
             '"block_height":"',
             block_height :: INTEGER,
             '"}'


### PR DESCRIPTION
- Fixes json parse object for `get_blocks__history` sql
- Adds `undo clone` make file directive
- Adds `target database` grant privileges for `aws lambda` role macro