### PR TITLE
add: model to backfill

### DIFF
--- a/models/silver/streamline/core/history/blocks/streamline__get_blocks_history.sql
+++ b/models/silver/streamline/core/history/blocks/streamline__get_blocks_history.sql
@@ -1,0 +1,32 @@
+{{ config(
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','{{ var('node_url') }}','external_table', 'blocks', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+WITH blocks AS (
+    SELECT
+        block_height
+    FROM
+        {{ ref("streamline__blocks") }}
+    EXCEPT
+    SELECT
+        block_number as block_height
+    FROM
+        {{ ref("streamline__complete_get_blocks") }}
+)
+SELECT
+    OBJECT_CONSTRUCT(
+        'grpc', 'proto3',
+        'method', 'get_block_by_height',
+        'block_height', block_height,
+        'method_params', OBJECT_CONSTRUCT('height', block_height)
+    ) AS request
+FROM
+    blocks
+WHERE
+    block_height BETWEEN {{ var('start_block') }} AND {{ var('end_block') }}
+ORDER BY
+    block_height ASC

--- a/models/silver/streamline/core/history/collections/streamline__get_collections_history.sql
+++ b/models/silver/streamline/core/history/collections/streamline__get_collections_history.sql
@@ -1,0 +1,41 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}', 'node_url', '{{ var('node_url') }}', 'external_table', 'collections', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+WITH blocks AS (
+    SELECT
+        block_height
+    FROM
+        {{ ref("streamline__blocks") }}
+    EXCEPT
+    SELECT
+        block_number as block_height
+    FROM
+        {{ ref("streamline__complete_get_collections") }}
+),
+collections AS (
+    SELECT
+        block_number as block_height,
+        data
+    FROM
+        {{ ref('streamline__complete_get_blocks') }}
+    JOIN blocks ON blocks.block_height = block_number
+)
+SELECT
+    OBJECT_CONSTRUCT(
+        'grpc', 'proto3',
+        'method', 'get_collection_by_i_d',
+        'block_height', block_height::INTEGER,
+        'method_params', OBJECT_CONSTRUCT('id', collection_guarantee.value:collection_id)
+    ) AS request
+FROM
+    collections,
+    LATERAL FLATTEN(input => data:collection_guarantees) AS collection_guarantee
+WHERE
+    block_height BETWEEN {{ var('start_block') }} AND {{ var('end_block') }}
+ORDER BY
+    block_height ASC

--- a/models/silver/streamline/core/history/collections/streamline__get_collections_history_mainnet22.sql
+++ b/models/silver/streamline/core/history/collections/streamline__get_collections_history_mainnet22.sql
@@ -1,44 +1,44 @@
-{{ config (
-    materialized = "view",
-    post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'collections', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
-        target = "{{this.schema}}.{{this.identifier}}"
+    {{ config (
+        materialized = "view",
+        post_hook = if_data_call_function(
+            func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'collections', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+            target = "{{this.schema}}.{{this.identifier}}"
+        )
+    ) }}
+
+    WITH blocks AS (
+
+        SELECT
+            block_height
+        FROM
+            {{ ref("streamline__blocks") }}
+        EXCEPT
+        SELECT
+            block_number as block_height
+        FROM
+            {{ ref("streamline__complete_get_collections") }}
+    ),
+    collections AS (
+
+        SELECT
+            block_number as block_height,
+            data
+        FROM
+            {{ ref('streamline__complete_get_blocks') }}
+        JOIN blocks ON blocks.block_height = block_number
     )
-) }}
-
-WITH blocks AS (
-
     SELECT
-        block_height
-    FROM
-        {{ ref("streamline__blocks") }}
-    EXCEPT
-    SELECT
-        block_number as block_height
-    FROM
-        {{ ref("streamline__complete_get_collections") }}
-),
-collections AS (
+        OBJECT_CONSTRUCT(
+            'grpc', 'proto3',
+            'method', 'get_collection_by_i_d',
+            'block_height', block_height::INTEGER,
+            'method_params', OBJECT_CONSTRUCT('id', collection_guarantee.value:collection_id)
+        ) AS request
 
-    SELECT
-        block_number as block_height,
-        data
     FROM
-        {{ ref('streamline__complete_get_blocks') }}
-    JOIN blocks ON blocks.block_height = block_number
-)
-SELECT
-    OBJECT_CONSTRUCT(
-        'grpc', 'proto3',
-        'method', 'get_collection_by_i_d',
-        'block_height', block_height::INTEGER,
-        'method_params', OBJECT_CONSTRUCT('id', collection_guarantee.value:collection_id)
-    ) AS request
-
-FROM
-    collections,
-    LATERAL FLATTEN(input => data:collection_guarantees) AS collection_guarantee
-WHERE
-    block_height BETWEEN 47169687 AND 55114466 -- Mainnet22 block range
-ORDER BY
-    block_height ASC
+        collections,
+        LATERAL FLATTEN(input => data:collection_guarantees) AS collection_guarantee
+    WHERE
+        block_height BETWEEN 47169687 AND 55114466 -- Mainnet22 block range
+    ORDER BY
+        block_height ASC

--- a/models/silver/streamline/core/history/transaction_results/streamline_get_transaction_results_history.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline_get_transaction_results_history.sql
@@ -1,0 +1,42 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}', 'node_url', {{ var('node_url') }}, 'external_table', 'transaction_results', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','30000')}}, 'worker_batch_size', {{var('worker_batch_size','3000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+WITH blocks AS (
+    SELECT
+        block_height
+    FROM
+        {{ ref("streamline__blocks") }}
+    EXCEPT
+    SELECT
+        block_number as block_height
+    FROM
+        {{ ref("streamline__complete_get_transaction_results") }}
+),
+tx AS (
+    SELECT
+        block_number as block_height,
+        data
+    FROM
+        {{ ref('streamline__complete_get_collections') }}
+    JOIN blocks ON blocks.block_height = block_number
+)
+SELECT
+    OBJECT_CONSTRUCT(
+        'grpc', 'proto3',
+        'method', 'get_transaction_result',
+        'block_height', block_height::INTEGER,
+        'transaction_id', transaction_id.value::string,
+        'method_params', OBJECT_CONSTRUCT('id',  transaction_id.value::string)
+    ) AS request
+FROM
+    tx,
+    LATERAL FLATTEN(input => TRY_PARSE_JSON(data):transaction_ids) AS transaction_id
+WHERE
+    block_height BETWEEN {{ var('start_block') }} AND {{ var('end_block') }}
+ORDER BY
+    block_height ASC

--- a/models/silver/streamline/core/history/transactions/streamline__get_transactions_history.sql
+++ b/models/silver/streamline/core/history/transactions/streamline__get_transactions_history.sql
@@ -1,0 +1,42 @@
+{{ config (
+    materialized = "view",
+    post_hook = if_data_call_function(
+        func = "{{this.schema}}.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}', 'node_url', {{ var('node_url') }}, 'external_table', 'transactions', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','30000')}}, 'worker_batch_size', {{var('worker_batch_size','3000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        target = "{{this.schema}}.{{this.identifier}}"
+    )
+) }}
+
+WITH blocks AS (
+    SELECT
+        block_height
+    FROM
+        {{ ref("streamline__blocks") }}
+    EXCEPT
+    SELECT
+        block_number as block_height
+    FROM
+        {{ ref("streamline__complete_get_transactions") }}
+),
+tx AS (
+    SELECT
+        block_number as block_height,
+        data
+    FROM
+        {{ ref('streamline__complete_get_collections') }}
+    JOIN blocks ON blocks.block_height = block_number
+)
+SELECT
+    OBJECT_CONSTRUCT(
+        'grpc', 'proto3',
+        'method', 'get_transaction',
+        'block_height', block_height::INTEGER,
+        'transaction_id', transaction_id.value::string,
+        'method_params', OBJECT_CONSTRUCT('id',  transaction_id.value::string)
+    ) AS request
+FROM
+    tx,
+    LATERAL FLATTEN(input => TRY_PARSE_JSON(data):transaction_ids) AS transaction_id
+WHERE
+    block_height BETWEEN {{ var('start_block') }} AND {{ var('end_block') }}
+ORDER BY
+    block_height ASC


### PR DESCRIPTION
Parameterize backfill models.

Getting again `Unknown user-defined function STREAMLINE.UDF_BULK_GRPC` but @ShahNewazKhan  looking at it.

Example
```
dbt run --model streamline__get_blocks_history --vars '{"node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 47169688, "STREAMLINE_INVOKE_STREAMS":True}'
```