### PR TITLE
Reduce backfill calls

### DIFF
--- a/.github/workflows/dbt_run_streamline_blocks.yml
+++ b/.github/workflows/dbt_run_streamline_blocks.yml
@@ -48,7 +48,3 @@ jobs:
       - name: Run DBT History Jobs - Mainnet22
         run: |
           dbt run -s 1+streamline__get_blocks_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'
-
-      - name: Run DBT History Jobs - Mainnet21
-        run: |
-          dbt run -s streamline__get_blocks_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'

--- a/.github/workflows/dbt_run_streamline_collections.yml
+++ b/.github/workflows/dbt_run_streamline_collections.yml
@@ -44,12 +44,3 @@ jobs:
       - name: Run DBT Realtime
         run: |
           dbt run -s 1+streamline__get_collections_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
-
-      - name: Run DBT History Jobs - Mainnet22
-        run: |
-          dbt run -s 1+streamline__get_collections_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'
-
-
-      - name: Run DBT History Jobs - Mainnet21
-        run: |
-          dbt run -s streamline__get_collections_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'

--- a/.github/workflows/dbt_run_streamline_transaction_results.yml
+++ b/.github/workflows/dbt_run_streamline_transaction_results.yml
@@ -44,12 +44,3 @@ jobs:
       - name: Run DBT Realtime
         run: |
           dbt run -s 1+streamline__get_transaction_results_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
-
-      - name: Run DBT History Jobs - Mainnet22
-        run: |
-          dbt run -s 1+streamline__get_transaction_results_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'
-
-
-      - name: Run DBT History Jobs - Mainnet21
-        run: |
-          dbt run -s streamline__get_transaction_results_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'

--- a/.github/workflows/dbt_run_streamline_transactions.yml
+++ b/.github/workflows/dbt_run_streamline_transactions.yml
@@ -44,12 +44,3 @@ jobs:
       - name: Run DBT Realtime
         run: |
           dbt run -s 1+streamline__get_transactions_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
-
-      - name: Run DBT History Jobs - Mainnet22
-        run: |
-          dbt run -s 1+streamline__get_transactions_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'
-
-
-      - name: Run DBT History Jobs - Mainnet21
-        run: |
-          dbt run -s streamline__get_transactions_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'


### PR DESCRIPTION
Deleting the following from the GHA workflows due to the shared rate limit. This will leave all 4 methods for the RT models, and just blocks for mainnet 22.

## Blocks
```
      - name: Run DBT History Jobs - Mainnet21
        run: |
          dbt run -s streamline__get_blocks_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'
```

## Collections
```
      - name: Run DBT History Jobs - Mainnet22
        run: |
          dbt run -s 1+streamline__get_collections_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'

      - name: Run DBT History Jobs - Mainnet21
        run: |
          dbt run -s streamline__get_collections_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'
```

## Txs
```

      - name: Run DBT History Jobs - Mainnet22
        run: |
          dbt run -s 1+streamline__get_transactions_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'

      - name: Run DBT History Jobs - Mainnet21
        run: |
          dbt run -s streamline__get_transactions_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'
```

## Tx Results
```
      - name: Run DBT History Jobs - Mainnet22
        run: |
          dbt run -s 1+streamline__get_transaction_results_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet22.nodes.onflow.org:9000", "start_block": 47169687, "end_block": 55114466}'

      - name: Run DBT History Jobs - Mainnet21
        run: |
          dbt run -s streamline__get_transaction_results_history --vars '{"STREAMLINE_INVOKE_STREAMS": True, "node_url": "access-001.mainnet21.nodes.onflow.org:9000", "start_block": 44950207, "end_block": 47169686}'
```