### PR TITLE
AN-3890/migrate udf

### DIFF
--- a/.github/workflows/dbt_run_moments_metadata.yml
+++ b/.github/workflows/dbt_run_moments_metadata.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # Runs 0000 UTC daily (see https://crontab.guru)
-    # - cron: '0 0 * * *'
-    # Runs hourly for next 30 hours, then reset to just daily
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 
 env:
   USE_VARS: "${{ vars.USE_VARS }}"

--- a/models/silver/_observability/silver_observability__block_tx_count.sql
+++ b/models/silver/_observability/silver_observability__block_tx_count.sql
@@ -39,7 +39,7 @@ params AS (
 ),
 get_bitquery AS (
     SELECT
-        flow.live.udf_api(
+        {{ target.database }}.live.udf_api(
             'POST',
             'https://graphql.bitquery.io',
             OBJECT_CONSTRUCT(

--- a/models/silver/_observability/silver_observability__block_tx_count.sql
+++ b/models/silver/_observability/silver_observability__block_tx_count.sql
@@ -39,7 +39,7 @@ params AS (
 ),
 get_bitquery AS (
     SELECT
-        livequery_dev.live.udf_api(
+        flow.live.udf_api(
             'POST',
             'https://graphql.bitquery.io',
             OBJECT_CONSTRUCT(

--- a/models/silver/nft/livequery/livequery__request_topshot_metadata.py
+++ b/models/silver/nft/livequery/livequery__request_topshot_metadata.py
@@ -74,16 +74,14 @@ def model(dbt, session):
         ['DATA', '_INSERTED_DATE', '_INSERTED_TIMESTAMP', '_RES_ID'],
         [
             F.call_udf(
-                'flow.streamline.udf_api',
+                'flow.live.udf_api',
                 method,
                 url,
                 headers,
                 udf_construct_data(
                     F.lit(data),
                     F.col('MOMENT_ID')
-                ),
-                F.lit(None),  # USER_ID req on Flow deployment of UDF_API
-                F.lit(None)  # SECRET_NAME req on Flow deployment of UDF_API
+                )
             ),
             F.sysdate().cast(T.DateType()),
             F.sysdate(),


### PR DESCRIPTION
Updates usage of `udf_api` to the new deployment in `.live`

Note - there is an error with the dev deployment of `udf_get_chainhead()`, for testing change `{{ target.database }}` in `silver_observability__block_tx_count` to `flow` to use the prod deployment.