### PR TITLE
AN-3939/add fix gap logic and obs models tests

### DIFF
--- a/.github/workflows/dbt_observability_models.yml
+++ b/.github/workflows/dbt_observability_models.yml
@@ -40,13 +40,9 @@ jobs:
           pip install -r requirements.txt
           dbt deps
 
-      - name: Run DBT Jobs - get_block_tx_count
+      - name: Run DBT Jobs - Bitquery getBlockTxCount and Observability models
         run: |
-          dbt run -s tag:get_block_tx_count --vars 'BITQUERY_API_KEY: ${{ secrets.BITQUERY_API_KEY }}'
-
-      - name: Run DBT Jobs - Observability models
-        run: |
-          dbt run -s tag:observability --exclude silver_observability__block_tx_count
+          dbt run -s tag:observability --vars 'BITQUERY_API_KEY: ${{ secrets.BITQUERY_API_KEY }}'
 
       - name: Store logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/dbt_observability_models.yml
+++ b/.github/workflows/dbt_observability_models.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run DBT Jobs - Observability models
         run: |
-          dbt run -s tag:observability
+          dbt run -s tag:observability --exclude silver_observability__block_tx_count
 
       - name: Store logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/dbt_test.yml
+++ b/.github/workflows/dbt_test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run DBT Jobs
         run: |
-          dbt test -s models/gold
+          dbt test -s models/gold tag:observability
         continue-on-error: true
 
       - name: Log test results

--- a/models/descriptions/blocks_impacted_array.md
+++ b/models/descriptions/blocks_impacted_array.md
@@ -1,0 +1,5 @@
+{% docs blocks_impacted_array %}
+
+Array of block numbers that were impacted during the test.
+
+{% enddocs %}

--- a/models/descriptions/blocks_impacted_count.md
+++ b/models/descriptions/blocks_impacted_count.md
@@ -1,0 +1,5 @@
+{% docs blocks_impacted_count %}
+
+Number of blocks impacted by a gap in the test.
+
+{% enddocs %}

--- a/models/descriptions/blocks_tested.md
+++ b/models/descriptions/blocks_tested.md
@@ -1,0 +1,6 @@
+{% docs blocks_tested %}
+
+Number of blocks tested
+
+{% enddocs %}
+

--- a/models/descriptions/max_block.md
+++ b/models/descriptions/max_block.md
@@ -1,0 +1,5 @@
+{% docs max_block %}
+
+The max block height in the test.
+
+{% enddocs %}

--- a/models/descriptions/max_block_timestamp.md
+++ b/models/descriptions/max_block_timestamp.md
@@ -1,0 +1,5 @@
+{% docs max_block_timestamp %}
+
+The max block timestamp in the test.
+
+{% enddocs %}

--- a/models/descriptions/min_block.md
+++ b/models/descriptions/min_block.md
@@ -1,0 +1,5 @@
+{% docs min_block %}
+
+The min block in the test.
+
+{% enddocs %}

--- a/models/descriptions/min_block_timestamp.md
+++ b/models/descriptions/min_block_timestamp.md
@@ -1,0 +1,5 @@
+{% docs min_block_timestamp %}
+
+The minimum block timestamp for the test.
+
+{% enddocs %}

--- a/models/descriptions/test_name.md
+++ b/models/descriptions/test_name.md
@@ -1,0 +1,5 @@
+{% docs test_name %}
+
+Name of the model being tested.
+
+{% enddocs %}

--- a/models/descriptions/test_timestamp.md
+++ b/models/descriptions/test_timestamp.md
@@ -1,0 +1,5 @@
+{% docs test_timestamp %}
+
+Timestamp of the test.
+
+{% enddocs %}

--- a/models/silver/_observability/silver_observability__block_tx_count.sql
+++ b/models/silver/_observability/silver_observability__block_tx_count.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'block_height',
-    tags = ['get_block_tx_count'],
+    tags = ['get_block_tx_count', 'observability'],
     full_refresh = False
 ) }}
 

--- a/models/silver/_observability/silver_observability__block_tx_count.sql
+++ b/models/silver/_observability/silver_observability__block_tx_count.sql
@@ -43,7 +43,7 @@
                 'block_height_start',
                 prev_block_height,
                 'block_height_end',
-                prev_block_height + gap - 1
+                (prev_block_height + gap - 1) :: INTEGER
             ) AS variables,
             '{{ var('BITQUERY_API_KEY', Null) }}' AS api_key
         FROM
@@ -75,7 +75,7 @@ params AS (
                 block_height_start + 25000 > max_block_height,
                 max_block_height - 500,
                 block_height_start + 25000
-            )
+            ) :: INTEGER
         ) AS variables,
         '{{ var('BITQUERY_API_KEY', Null) }}' AS api_key
     FROM

--- a/models/silver/_observability/silver_observability__block_tx_count.yml
+++ b/models/silver/_observability/silver_observability__block_tx_count.yml
@@ -24,5 +24,3 @@ models:
           - not_null
 
       - name: _inserted_timestamp
-        tests: 
-          - not_null

--- a/models/silver/_observability/silver_observability__block_tx_count.yml
+++ b/models/silver/_observability/silver_observability__block_tx_count.yml
@@ -1,0 +1,28 @@
+version: 2
+
+models:
+  - name: silver_observability__block_tx_count
+    description: |-
+      Query the Bitquery graphQL API to get transaction count by block number.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: _inserted_timestamp
+          interval: 1
+      - sequence_gaps:
+          column_name: block_height
+          severity: error
+
+    columns:
+      - name: block_height
+        tests:
+          - unique
+          - not_null
+
+      - name: transaction_ct
+        tests:
+          - not_null
+
+      - name: _inserted_timestamp
+        tests: 
+          - not_null

--- a/models/silver/_observability/silver_observability__blocks_completeness.yml
+++ b/models/silver/_observability/silver_observability__blocks_completeness.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: silver_observability__blocks_completeness
+    description: |-
+      Observability model that queries the blocks table at a designated interval to record and track the completeness of the data.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: test_timestamp
+          interval: 1
+      - dbt_utils.recency:
+          datepart: hours
+          field: max_block_timestamp
+          interval: 24
+
+    columns:
+      - name: TEST_NAME
+        description: "{{ doc('test_name') }}"
+
+      - name: MIN_BLOCK
+        description: "{{ doc('min_block') }}"
+
+      - name: MAX_BLOCK
+        description: "{{ doc('max_block') }}"
+
+      - name: MIN_BLOCK_TIMESTAMP
+        description: "{{ doc('min_block_timestamp') }}"
+
+      - name: MAX_BLOCK_TIMESTAMP
+        description: "{{ doc('max_block_timestamp') }}"
+
+      - name: BLOCKS_TESTED
+        description: "{{ doc('blocks_tested') }}"
+
+      - name: BLOCKS_IMPACTED_COUNT
+        description: "{{ doc('blocks_impacted_count') }}"
+
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: "{{ doc('blocks_impacted_array') }}"
+
+      - name: TEST_TIMESTAMP
+        description: "{{ doc('test_timestamp') }}"

--- a/models/silver/_observability/silver_observability__txs_completeness.yml
+++ b/models/silver/_observability/silver_observability__txs_completeness.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: silver_observability__txs_completeness
+    description: |-
+      Observability model that queries the txs table at a designated interval to record and track the completeness of the data.
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: test_timestamp
+          interval: 1
+      - dbt_utils.recency:
+          datepart: hours
+          field: max_block_timestamp
+          interval: 24
+
+    columns:
+      - name: TEST_NAME
+        description: "{{ doc('test_name') }}"
+
+      - name: MIN_BLOCK
+        description: "{{ doc('min_block') }}"
+
+      - name: MAX_BLOCK
+        description: "{{ doc('max_block') }}"
+
+      - name: MIN_BLOCK_TIMESTAMP
+        description: "{{ doc('min_block_timestamp') }}"
+
+      - name: MAX_BLOCK_TIMESTAMP
+        description: "{{ doc('max_block_timestamp') }}"
+
+      - name: BLOCKS_TESTED
+        description: "{{ doc('blocks_tested') }}"
+
+      - name: BLOCKS_IMPACTED_COUNT
+        description: "{{ doc('blocks_impacted_count') }}"
+
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: "{{ doc('blocks_impacted_array') }}"
+
+      - name: TEST_TIMESTAMP
+        description: "{{ doc('test_timestamp') }}"

--- a/tests/tests__block_tx_count_recency.sql
+++ b/tests/tests__block_tx_count_recency.sql
@@ -1,0 +1,25 @@
+{{ config(
+    severity = 'error',
+    tags = ['observability']
+) }}
+
+WITH check_lag AS (
+
+    SELECT
+        {{ target.database }}.streamline.udf_get_chainhead() AS chainhead,
+        (
+            SELECT
+                MAX(block_height)
+            FROM
+                {{ ref('silver_observability__block_tx_count') }}
+        ) AS max_height,
+        (
+            chainhead - max_height < 25000
+        ) AS is_recent
+)
+SELECT
+    *
+FROM
+    check_lag
+WHERE
+    NOT is_recent


### PR DESCRIPTION
Adds logic to query any gaps in the bitquery table. Gap may be due to unsealed blocks, so also adding a 500 block buffer on chainhead. We'd get them on the next run (happens 4x/day).

Currently getting no response for the 20 blocks from `60965021` to `60965040`

Adds recency tests to the complete blocks and txs table