### PR TITLE
Quickfix - Update `retry_tx_ids` in txs final

### DIFF
--- a/models/silver/core/silver__streamline_transactions_final.sql
+++ b/models/silver/core/silver__streamline_transactions_final.sql
@@ -8,7 +8,8 @@
 WITH retry_tx_ids AS (
 
     SELECT
-        tx_id
+        tx_id,
+        block_height
     FROM
         {{ this }}
     WHERE
@@ -80,7 +81,7 @@ WHERE
             MAX(DATE_TRUNC('day', _inserted_timestamp))
         FROM
             {{ this }}
-    ) - INTERVAL '24 hours'
+    ) - INTERVAL '3 days'
 {% endif %}
 ),
 FINAL AS (

--- a/models/silver/core/silver__streamline_transactions_final.sql
+++ b/models/silver/core/silver__streamline_transactions_final.sql
@@ -12,8 +12,7 @@ WITH retry_tx_ids AS (
     FROM
         {{ this }}
     WHERE
-        (_inserted_timestamp >= SYSDATE() - INTERVAL '3 days'
-        OR _inserted_timestamp IS NULL)
+        _inserted_timestamp >= SYSDATE() - INTERVAL '3 days'
         AND (
             block_timestamp IS NULL
             OR pending_result_response

--- a/models/silver/core/silver__streamline_transactions_final.sql
+++ b/models/silver/core/silver__streamline_transactions_final.sql
@@ -12,7 +12,8 @@ WITH retry_tx_ids AS (
     FROM
         {{ this }}
     WHERE
-        _inserted_timestamp >= SYSDATE() - INTERVAL '3 days'
+        (_inserted_timestamp >= SYSDATE() - INTERVAL '3 days'
+        OR _inserted_timestamp IS NULL)
         AND (
             block_timestamp IS NULL
             OR pending_result_response
@@ -117,10 +118,10 @@ FINAL AS (
         tr.status,
         tr.status_code,
         GREATEST(
-            b._inserted_timestamp,
-            tr._inserted_timestamp,
-            t._inserted_timestamp
-        ) :: timestamp_ntz AS _inserted_timestamp,
+            [b._inserted_timestamp],
+            [tr._inserted_timestamp],
+            [t._inserted_timestamp]
+        ) [0] :: timestamp_ntz AS _inserted_timestamp,
         t._partition_by_block_id
     FROM
         txs t

--- a/models/silver/core/silver__streamline_transactions_final.yml
+++ b/models/silver/core/silver__streamline_transactions_final.yml
@@ -24,7 +24,8 @@ models:
       - name: block_timestamp
         description: "{{ doc('block_timestamp') }}"
         tests:
-          - not_null
+          - not_null:
+              where: block_height >= {{ var('STREAMLINE_START_BLOCK' )}}
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: TIMESTAMP_NTZ
 

--- a/models/silver/core/silver__streamline_transactions_final.yml
+++ b/models/silver/core/silver__streamline_transactions_final.yml
@@ -105,6 +105,8 @@ models:
 
       - name: _inserted_timestamp
         description: "{{ doc('_inserted_timestamp') }}"
+        tests:
+          - not_null
 
       - name: _partition_by_block_id
         description: "{{ doc('_partition_by_block_id') }}"


### PR DESCRIPTION
`GREATEST()` was resulting in null `_inserted_timestamp`s, adjusted logic per solution [here](https://stackoverflow.com/questions/74527418/how-to-use-greatest-in-snowflake-with-null-values)