### PR TITLE
modify how dbt performs merges by default

### DIFF
--- a/macros/custom_naming_macros.sql
+++ b/macros/custom_naming_macros.sql
@@ -15,3 +15,9 @@
     {% set split_name = node_name.split('__') %}
     {{ split_name [1] | trim }}
 {%- endmacro %}
+
+{% macro generate_tmp_view_name(model_name) -%}
+    {% set node_name = model_name.name %}
+    {% set split_name = node_name.split('__') %}
+    {{ target.database ~ '.' ~ split_name[0] ~ '.' ~ split_name [1] ~ '__dbt_tmp' | trim }}
+{%- endmacro %}

--- a/macros/dbt/get_tmp_relation_type.sql
+++ b/macros/dbt/get_tmp_relation_type.sql
@@ -1,0 +1,4 @@
+{% macro dbt_snowflake_get_tmp_relation_type(strategy, unique_key, language) %}
+    -- always table
+    {{ return('table') }}
+{% endmacro %}


### PR DESCRIPTION
- Change default merge behavior within Snowflake to use a temporary table instead of a temporary view. Temp tables are required for incremental predicates to work properly on merges.