### PR TITLE
add streamline vars as repo vars and upd history workflow

### DIFF
--- a/.github/workflows/dbt_run_history.yml
+++ b/.github/workflows/dbt_run_history.yml
@@ -28,7 +28,7 @@ jobs:
     uses: FlipsideCrypto/analytics-workflow-templates/.github/workflows/dbt_run_template.yml@main
     with:
       dbt_command: >
-        dbt run -s 2+models/silver/streamline/core/history/ --vars '{"STREAMLINE_INVOKE_STREAMS": True}'
+        dbt run -s 2+models/silver/streamline/core/history/ --vars '{"STREAMLINE_INVOKE_STREAMS": True, "sql_limit": ${{ vars.SQL_LIMIT_HISTORY }}, "producer_batch_size": ${{ vars.PRODUCER_BATCH_SIZE_HISTORY }}, "worker_batch_size": ${{ vars.WORKER_BATCH_SIZE_HISTORY }}, "batch_call_limit": ${{ vars.BATCH_CALL_LIMIT_HISTORY }}}'
       environment: workflow_prod
       warehouse: ${{ vars.WAREHOUSE }}
     secrets: inherit 


### PR DESCRIPTION
4 streamline vars added as CLI input and set in the repository to allow for tweaking without PR. Currently set to the default value(s).