### PR TITLE
disable block tx count recency test

### DIFF
--- a/tests/tests__block_tx_count_recency.sql
+++ b/tests/tests__block_tx_count_recency.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity = 'error',
-    tags = ['observability']
+    tags = ['observability'],
+    enabled = False
 ) }}
 
 WITH check_lag AS (


### PR DESCRIPTION
Legacy workflow that relied on the bitquery api for block tx counts