### PR TITLE
BACKFILL/add excl epoch payout flag

### DIFF
--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_08.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_08.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet8.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_08', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet8.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_08', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_09.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_09.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet9.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_09', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet9.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_09', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_10.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_10.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet10.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_10', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet10.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_10', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_11.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_11.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet11.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_11', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet11.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_11', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_12.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_12.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet12.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_12', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet12.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_12', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_13.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_13.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet13.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_13', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet13.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_13', 'sql_limit', '5', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_14.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_14.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet14.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_14', 'sql_limit', '5000', 'producer_batch_size','500',  'worker_batch_size','25', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet14.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_14', 'sql_limit', '10', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "streamline.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_15.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_15.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet15.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_15','sql_limit', '5000', 'producer_batch_size','500',  'worker_batch_size','25', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet15.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_15','sql_limit', '10', 'producer_batch_size','5',  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "streamline.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_16.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_16.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet16.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_16', 'sql_limit', '10', 'producer_batch_size','5'  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet16.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_16', 'sql_limit', '10', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "streamline.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_16.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_16.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet16.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_16', 'sql_limit', '5000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "streamline.udf_bulk_grpc(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet16.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_16', 'sql_limit', '10', 'producer_batch_size','5'  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "streamline.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '10', 'producer_batch_size','5',  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '500000', 'producer_batch_size','10000',  'worker_batch_size','250', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet17.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_17', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_17.sql
@@ -21,6 +21,17 @@ WITH collection_transactions AS (
         block_height BETWEEN 27341470
         AND 31735954
 ),
+epoch_payments AS (
+    SELECT
+        block_number AS block_height,
+        id AS transaction_id
+    FROM
+        {{ ref ('streamline__complete_get_transactions_history') }} t
+    WHERE 
+        (block_number BETWEEN 27341470 AND 31735954)
+        AND
+        data:script::string like '%import FlowEpoch%' and array_size(data:arguments::array) = 6
+),
 -- CTE to identify transactions that haven't been ingested yet
 transactions_to_ingest AS (
     SELECT
@@ -31,8 +42,11 @@ transactions_to_ingest AS (
         LEFT JOIN {{ ref("streamline__complete_get_transaction_results_history") }}
         t
         ON ct.transaction_id = t.id
+        LEFT JOIN epoch_payments ep
+        ON ct.transaction_id = ep.transaction_id
     WHERE
         t.id IS NULL
+        AND ep.transaction_id IS NULL
 ) -- Generate the requests based on the missing transactions
 SELECT
     OBJECT_CONSTRUCT(

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '10', 'producer_batch_size','5',  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '500000', 'producer_batch_size','10000',  'worker_batch_size','250', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet18.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_18', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_18.sql
@@ -20,6 +20,17 @@ WITH collection_transactions AS (
         block_height BETWEEN 31735955
         AND 35858810
 ),
+epoch_payments AS (
+    SELECT
+        block_number AS block_height,
+        id AS transaction_id
+    FROM
+        {{ ref ('streamline__complete_get_transactions_history') }} t
+    WHERE 
+        (block_number BETWEEN 31735955 AND 35858810)
+        AND
+        data:script::string like '%import FlowEpoch%' and array_size(data:arguments::array) = 6
+),
 -- CTE to identify transactions that haven't been ingested yet
 transactions_to_ingest AS (
     SELECT
@@ -30,8 +41,11 @@ transactions_to_ingest AS (
         LEFT JOIN {{ ref("streamline__complete_get_transaction_results_history") }}
         t
         ON ct.transaction_id = t.id
+        LEFT JOIN epoch_payments ep
+        ON ct.transaction_id = ep.transaction_id
     WHERE
         t.id IS NULL
+        AND ep.transaction_id IS NULL
 ) -- Generate the requests based on the missing transactions
 SELECT
     OBJECT_CONSTRUCT(

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '10', 'producer_batch_size','5',  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_19.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '500000', 'producer_batch_size','10000',  'worker_batch_size','250', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet19.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_19','sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '2000', 'producer_batch_size', '500', 'worker_batch_size', '50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '100', 'producer_batch_size', '10', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
@@ -21,6 +21,17 @@ WITH collection_transactions AS (
         block_height BETWEEN 40171634
         AND 44950206
 ),
+epoch_payments AS (
+    SELECT
+        block_number AS block_height,
+        id AS transaction_id
+    FROM
+        {{ ref ('streamline__complete_get_transactions_history') }} t
+    WHERE 
+        (block_number BETWEEN 40171634 AND 44950206)
+        AND
+        data:script::string like '%import FlowEpoch%' and array_size(data:arguments::array) = 6
+),
 -- CTE to identify transactions that haven't been ingested yet
 transactions_to_ingest AS (
     SELECT
@@ -31,8 +42,11 @@ transactions_to_ingest AS (
         LEFT JOIN {{ ref("streamline__complete_get_transaction_results_history") }}
         t
         ON ct.transaction_id = t.id
+        LEFT JOIN epoch_payments ep
+        ON ct.transaction_id = ep.transaction_id
     WHERE
         t.id IS NULL
+        AND ep.transaction_id IS NULL
 ) -- Generate the requests based on the missing transactions
 SELECT
     OBJECT_CONSTRUCT(

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '100', 'producer_batch_size', '10', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '500', 'producer_batch_size', '50', 'worker_batch_size', '5', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '2000', 'producer_batch_size', '1000', 'worker_batch_size', '100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_20.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '2000', 'producer_batch_size', '1000', 'worker_batch_size', '100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet20.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_20', 'sql_limit', '2000', 'producer_batch_size', '500', 'worker_batch_size', '50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
@@ -21,6 +21,17 @@ WITH collection_transactions AS (
         block_height BETWEEN 44950207
         AND 47169686
 ),
+epoch_payments AS (
+    SELECT
+        block_number AS block_height,
+        id AS transaction_id
+    FROM
+        {{ ref ('streamline__complete_get_transactions_history') }} t
+    WHERE 
+        (block_number BETWEEN 44950207 AND 47169686)
+        AND
+        data:script::string like '%import FlowEpoch%' and array_size(data:arguments::array) = 6
+),
 -- CTE to identify transactions that haven't been ingested yet
 transactions_to_ingest AS (
     SELECT
@@ -31,8 +42,11 @@ transactions_to_ingest AS (
         LEFT JOIN {{ ref("streamline__complete_get_transaction_results_history") }}
         t
         ON ct.transaction_id = t.id
+        LEFT JOIN epoch_payments ep
+        ON ct.transaction_id = ep.transaction_id
     WHERE
         t.id IS NULL
+        AND ep.transaction_id IS NULL
 ) -- Generate the requests based on the missing transactions
 SELECT
     OBJECT_CONSTRUCT(

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', '2000', 'producer_batch_size', '1000', 'worker_batch_size', '100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', '2000', 'producer_batch_size', '500', 'worker_batch_size', '50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', {{var('sql_limit','500000')}}, 'producer_batch_size', {{var('producer_batch_size','10000')}}, 'worker_batch_size', {{var('worker_batch_size','1000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', '2000', 'producer_batch_size', '1000', 'worker_batch_size', '100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_21.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', '2000', 'producer_batch_size', '500', 'worker_batch_size', '50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet21.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_21', 'sql_limit', '10', 'producer_batch_size', '5', 'worker_batch_size', '1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '500000', 'producer_batch_size','10000',  'worker_batch_size','250', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
@@ -21,6 +21,17 @@ WITH collection_transactions AS (
         block_height BETWEEN 47169687
         AND 55114466
 ),
+epoch_payments AS (
+    SELECT
+        block_number AS block_height,
+        id AS transaction_id
+    FROM
+        {{ ref ('streamline__complete_get_transactions_history') }} t
+    WHERE 
+        (block_number BETWEEN 47169687 AND 55114466)
+        AND
+        data:script::string like '%import FlowEpoch%' and array_size(data:arguments::array) = 6
+),
 -- CTE to identify transactions that haven't been ingested yet
 transactions_to_ingest AS (
     SELECT
@@ -31,8 +42,11 @@ transactions_to_ingest AS (
         LEFT JOIN {{ ref("streamline__complete_get_transaction_results_history") }}
         t
         ON ct.transaction_id = t.id
+        LEFT JOIN epoch_payments ep
+        ON ct.transaction_id = ep.transaction_id
     WHERE
         t.id IS NULL
+        AND ep.transaction_id IS NULL
 ) -- Generate the requests based on the missing transactions
 SELECT
     OBJECT_CONSTRUCT(

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '10', 'producer_batch_size','5',  'worker_batch_size','1', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
+++ b/models/silver/streamline/core/history/transaction_results/streamline__get_transaction_results_history_mainnet_22.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '2000', 'producer_batch_size','1000',  'worker_batch_size','100', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_grpc_us_east_2(object_construct('sql_source', '{{this.identifier}}','node_url','access-001.mainnet22.nodes.onflow.org:9000','external_table', 'transaction_results_mainnet_22', 'sql_limit', '2000', 'producer_batch_size','500',  'worker_batch_size','50', 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}


### PR DESCRIPTION
Exclude large epoch payout tx hash from request due to memory issue

```shell
dbt run -s \
2+streamline__get_transaction_results_history_mainnet_17 \
2+streamline__get_transaction_results_history_mainnet_18 \
2+streamline__get_transaction_results_history_mainnet_19 \
2+streamline__get_transaction_results_history_mainnet_20 \
2+streamline__get_transaction_results_history_mainnet_21 \
2+streamline__get_transaction_results_history_mainnet_22 \
--vars '{"STREAMLINE_INVOKE_STREAMS": True}'
```