### PR TITLE
AN-5236/new transfers model

### DIFF
--- a/models/descriptions/amount_adj.md
+++ b/models/descriptions/amount_adj.md
@@ -1,0 +1,5 @@
+{% docs amount_adj %}
+
+An amount with decimal adjustment applied.
+
+{% enddocs %}

--- a/models/descriptions/deposited_uuid.md
+++ b/models/descriptions/deposited_uuid.md
@@ -1,5 +1,0 @@
-{% docs deposited_uuid %}
-
-The UUID of the transfer that was deposited to the recipient.
-
-{% enddocs %}

--- a/models/descriptions/deposited_uuid.md
+++ b/models/descriptions/deposited_uuid.md
@@ -1,0 +1,5 @@
+{% docs deposited_uuid %}
+
+The UUID of the transfer that was deposited to the recipient.
+
+{% enddocs %}

--- a/models/descriptions/deposited_uuid_root.md
+++ b/models/descriptions/deposited_uuid_root.md
@@ -1,0 +1,5 @@
+{% docs deposited_uuid_root %}
+
+The UUID of the transfer that was deposited to the recipient. This is the root deposit, as certain transfers that utilize a Vault may have two subsequent Deposited events.
+
+{% enddocs %}

--- a/models/descriptions/from_address_balance_after.md
+++ b/models/descriptions/from_address_balance_after.md
@@ -1,0 +1,5 @@
+{% docs from_address_balance_after %}
+
+The token balance of the withdrawn token in the sender account after the transfer.
+
+{% enddocs %}

--- a/models/descriptions/is_fee_transfer.md
+++ b/models/descriptions/is_fee_transfer.md
@@ -1,0 +1,5 @@
+{% docs is_fee_transfer %}
+
+A boolean field indicating if the transfer was the transaction fee payment, as assessed by to_uuid = 0
+
+{% enddocs %}

--- a/models/descriptions/to_address_balance_after.md
+++ b/models/descriptions/to_address_balance_after.md
@@ -1,0 +1,5 @@
+{% docs to_address_balance_after %}
+
+The token balance of the deposited token in the recipient account after the transfer.
+
+{% enddocs %}

--- a/models/descriptions/withdrawn_uuid_root.md
+++ b/models/descriptions/withdrawn_uuid_root.md
@@ -1,0 +1,5 @@
+{% docs withdrawn_uuid_root %}
+
+The UUID of the transfer that was withdrawn from the sender's account. This is the root withdrawal, as certain transfers that utilize a Vault may have two subsequent Withdrawal events.
+
+{% enddocs %}

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -4,17 +4,11 @@ models:
   - name: core__ez_token_transfers
     description: |-
       This table records all token transfers on the FLOW blockchain.
-
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - tx_id
-            - sender
-            - recipient
-            - token_contract
-            - amount
-          config:
-            severity: warn
+      - dbt_utils.recency:
+          datepart: hour
+          field: block_timestamp
+          interval: 1
 
     columns:
       - name: TX_ID
@@ -45,7 +39,6 @@ models:
       - name: SENDER
         description: "{{ doc('sender') }}"
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - STRING
@@ -87,6 +80,10 @@ models:
 
       - name: EZ_TOKEN_TRANSFERS_ID
         description: "{{ doc('pk_id') }}"
+        tests:
+          - not_null
+          - unique:
+              where: block_height >= 85981726
 
       - name: INSERTED_TIMESTAMP
         description: "{{ doc('inserted_timestamp') }}"

--- a/models/silver/transfers/silver__token_transfers.sql
+++ b/models/silver/transfers/silver__token_transfers.sql
@@ -5,7 +5,6 @@
     incremental_predicates = ["COALESCE(DBT_INTERNAL_DEST.block_timestamp::DATE,'2099-12-31') >= (select min(block_timestamp::DATE) from " ~ generate_tmp_view_name(this) ~ ")"],
     cluster_by = ['block_timestamp::date', 'modified_timestamp::date'],
     unique_key = "token_transfers_id",
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,from_address,to_address,token_contract);",
     tags = ['scheduled_non_core']
 ) }}
 

--- a/models/silver/transfers/silver__token_transfers.sql
+++ b/models/silver/transfers/silver__token_transfers.sql
@@ -1,0 +1,168 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    cluster_by = ['block_timestamp::date', 'modified_timestamp::date'],
+    unique_key = "token_transfers_id",
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,from_address,to_address,token_contract);",
+    tags = ['scheduled_non_core']
+) }}
+
+WITH events AS (
+
+    SELECT
+        block_height,
+        block_timestamp,
+        tx_id,
+        tx_succeeded,
+        event_index,
+        event_type,
+        event_contract,
+        event_data,
+        _inserted_timestamp,
+        modified_timestamp
+    FROM
+        {{ ref('silver__streamline_events') }}
+    WHERE
+        _partition_by_block_id >= 85000000
+        AND block_height >= 85981726
+        AND (
+            (
+                event_contract = 'A.f233dcee88fe0abe.FungibleToken'
+                AND event_type IN (
+                    'Withdrawn',
+                    'Deposited'
+                )
+            )
+            OR (
+                -- no initial "Withdrawal" event if it's a new token mint
+                event_type IN ('TokensMinted'))
+            )
+
+{% if is_incremental() %}
+AND modified_timestamp > (
+    SELECT
+        MAX(modified_timestamp)
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+withdrawn AS (
+    SELECT
+        tx_id,
+        event_index,
+        event_contract,
+        event_data :amount :: STRING AS amount_adj,
+        event_data :balanceAfter :: STRING AS balance_after_adj,
+        event_data :from :: STRING AS from_address,
+        event_data :fromUUID :: STRING AS from_uuid,
+        event_data :type :: STRING AS token_type,
+        event_data :withdrawnUUID :: STRING AS withdrawn_uuid,
+        _inserted_timestamp
+    FROM
+        events
+    WHERE
+        event_type = 'Withdrawn'
+),
+deposited AS (
+    SELECT
+        tx_id,
+        event_index,
+        block_height,
+        block_timestamp,
+        event_contract,
+        event_data :amount :: STRING AS amount_adj,
+        event_data :balanceAfter :: STRING AS balance_after_adj,
+        event_data :depositedUUID :: STRING AS deposited_uuid,
+        event_data :to :: STRING AS to_address,
+        event_data :toUUID :: STRING AS to_uuid,
+        event_data :type :: STRING AS token_type,
+        row_number() OVER (
+            PARTITION BY tx_id
+            ORDER BY
+                event_index
+        ) AS rn,
+        tx_succeeded,
+        _inserted_timestamp
+    FROM
+        events
+    WHERE
+        event_type = 'Deposited'
+),
+minted AS (
+    SELECT
+        tx_id,
+        event_index,
+        event_contract AS token_type,
+        event_data :amount :: STRING AS amount_adj,
+        COALESCE(
+            event_data :from :: STRING,
+            event_data :type :: STRING
+        ) AS from_address,
+        '-1' AS withdrawn_uuid,
+        row_number() OVER (
+            PARTITION BY tx_id
+            ORDER BY
+                event_index
+        ) AS rn
+    FROM
+        events
+    WHERE
+        event_type = 'TokensMinted'
+)
+SELECT
+    d.deposited_uuid,
+    COALESCE(
+        w2.withdrawn_uuid,
+        w.withdrawn_uuid,
+        m.withdrawn_uuid
+    ) AS withdrawn_uuid_root,
+    d.tx_id,
+    d.block_height,
+    d.block_timestamp,
+    REGEXP_REPLACE(
+        COALESCE(
+            w2.token_type,
+            w.token_type,
+            m.token_type
+        ),
+        '\.Vault$',
+        ''
+    ) AS token_contract,
+    COALESCE(
+        w2.from_address,
+        w.from_address,
+        m.from_address
+    ) AS from_address,
+    d.to_address,
+    COALESCE(
+        w2.amount_adj,
+        w.amount_adj,
+        m.amount_adj
+    ) AS amount_adj,
+    COALESCE(
+        w2.balance_after_adj,
+        w.balance_after_adj
+    ) AS from_address_balance_after,
+    d.balance_after_adj AS to_address_balance_after,
+    d.to_uuid = '0' AS is_fee_transfer,
+    d.tx_succeeded,
+    d._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['d.tx_id', 'd.deposited_uuid :: STRING', 'withdrawn_uuid_root :: STRING']
+    ) }} AS token_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    deposited d
+    LEFT JOIN withdrawn w
+    ON d.tx_id = w.tx_id
+    AND d.deposited_uuid = w.withdrawn_uuid
+    LEFT JOIN withdrawn w2
+    ON d.tx_id = w2.tx_id
+    AND w.from_uuid = w2.withdrawn_uuid
+    LEFT JOIN minted m
+    ON d.tx_id = m.tx_id
+    AND d.amount_adj = m.amount_adj
+    AND d.rn = m.rn

--- a/models/silver/transfers/silver__token_transfers.yml
+++ b/models/silver/transfers/silver__token_transfers.yml
@@ -1,0 +1,93 @@
+version: 2
+
+models:
+  - name: silver__token_transfers
+    description: |-
+      This table records all token transfers on the FLOW blockchain from after the Crescendo upgrade.
+    tests:
+      - dbt_utils.recency:
+          datepart: hour
+          field: block_timestamp
+          interval: 1
+
+    columns:
+      - name: DEPOSITED_UUID
+        description: "{{ doc('deposited_uuid') }}"
+        tests:
+          - not_null
+
+      - name: WITHDRAWN_UUID_ROOT
+        description: "{{ doc('withdrawn_uuid_root') }}"
+        tests:
+          - not_null
+
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+ 
+      - name: BLOCK_HEIGHT
+        description: "{{ doc('block_height') }}"
+        tests:
+          - not_null
+
+      - name: TOKEN_CONTRACT
+        description: "{{ doc('token_contract') }}"
+        tests:
+          - not_null
+
+      - name: FROM_ADDRESS
+        description: "{{ doc('sender') }}"
+        tests:
+          - not_null
+
+      - name: TO_ADDRESS
+        description: "{{ doc('recipient') }}"
+        tests:
+          - not_null
+
+      - name: AMOUNT_ADJ
+        description: "{{ doc('amount_adj') }}"
+        tests:
+          - not_null
+
+      - name: FROM_ADDRESS_BALANCE_AFTER
+        description: "{{ doc('from_address_balance_after') }}"
+        tests:
+          - not_null:
+              where: WITHDRAWN_UUID_ROOT != '-1'
+
+      - name: TO_ADDRESS_BALANCE_AFTER
+        description: "{{ doc('to_address_balance_after') }}"
+        tests:
+          - not_null
+
+      - name: IS_FEE_TRANSFER
+        description: "{{ doc('is_fee_transfer') }}"
+        tests:
+          - not_null
+
+      - name: TX_SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+
+      - name: TOKEN_TRANSFERS_ID
+        description: "{{ doc('pk_id') }}"
+        tests:
+          - not_null
+          - unique
+
+      - name: INSERTED_TIMESTAMP
+        description: "{{ doc('inserted_timestamp') }}"
+
+      - name: MODIFIED_TIMESTAMP
+        description: "{{ doc('modified_timestamp') }}"
+
+      - name: _INVOCATION_ID
+        description: "{{ doc('invocation_id') }}"

--- a/models/silver/transfers/silver__token_transfers.yml
+++ b/models/silver/transfers/silver__token_transfers.yml
@@ -11,15 +11,13 @@ models:
           interval: 1
 
     columns:
-      - name: DEPOSITED_UUID
-        description: "{{ doc('deposited_uuid') }}"
+      - name: DEPOSITED_UUID_ROOT
+        description: "{{ doc('deposited_uuid_root') }}"
         tests:
           - not_null
 
       - name: WITHDRAWN_UUID_ROOT
         description: "{{ doc('withdrawn_uuid_root') }}"
-        tests:
-          - not_null
 
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
@@ -44,7 +42,8 @@ models:
       - name: FROM_ADDRESS
         description: "{{ doc('sender') }}"
         tests:
-          - not_null
+          - not_null:
+              where: WITHDRAWN_UUID_ROOT != '-1'
 
       - name: TO_ADDRESS
         description: "{{ doc('recipient') }}"

--- a/models/silver/transfers/silver__token_transfers_s.sql
+++ b/models/silver/transfers/silver__token_transfers_s.sql
@@ -3,7 +3,6 @@
     incremental_strategy = 'delete+insert',
     cluster_by = ['block_timestamp::date', 'modified_timestamp::date'],
     unique_key = "CONCAT_WS('-', tx_id, sender, recipient, token_contract, amount)",
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,sender,recipient,token_contract);",
     tags = ['scheduled', 'streamline_scheduled', 'scheduled_non_core']
 ) }}
 

--- a/models/silver/transfers/silver__token_transfers_s.sql
+++ b/models/silver/transfers/silver__token_transfers_s.sql
@@ -29,7 +29,7 @@ WITH events AS (
         AND block_height < 85981726
 
 {% if is_incremental() %}
-WHERE
+AND
     modified_timestamp >= (
         SELECT
             MAX(modified_timestamp)

--- a/models/silver/transfers/silver__token_transfers_s.sql
+++ b/models/silver/transfers/silver__token_transfers_s.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp::date'],
+    cluster_by = ['block_timestamp::date', 'modified_timestamp::date'],
     unique_key = "CONCAT_WS('-', tx_id, sender, recipient, token_contract, amount)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,sender,recipient,token_contract);",
     tags = ['scheduled', 'streamline_scheduled', 'scheduled_non_core']
@@ -23,8 +23,10 @@ WITH events AS (
         modified_timestamp
     FROM
         {{ ref('silver__streamline_events') }}
-        -- WHERE
-        --     event_data :: STRING != '{}'
+    WHERE
+        -- crescendo upgrade cutoff
+        _partition_by_block_id <= 86000000
+        AND block_height < 85981726
 
 {% if is_incremental() %}
 WHERE
@@ -155,7 +157,10 @@ FINAL AS (
 )
 SELECT
     *,
-    round(block_height, -5) AS _partition_by_block_id,
+    ROUND(
+        block_height,
+        -5
+    ) AS _partition_by_block_id,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id','sender', 'recipient','token_contract', 'amount']
     ) }} AS token_transfers_id,

--- a/models/silver/transfers/silver__token_transfers_s.yml
+++ b/models/silver/transfers/silver__token_transfers_s.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: silver__token_transfers_s
     description: |-
-      This table records all token transfers on the FLOW blockchain.
+      This table records all token transfers on the FLOW blockchain from before the Crescendo upgrade.
 
     columns:
       - name: tx_id


### PR DESCRIPTION
Deploys new transfers model for post-crescendo `Withdrawn` and `Deposited` events.

121 transfers in the old model, delete with:
```sql
delete from flow.silver.token_transfers_s
where block_height >= 85981726;
```

Migrates the `core.ez_token_transfers` from a view to incremental model with SO due to the `UNION ALL`

There's a number of new useful fields in the transfer events that Flow now emits. Most notably `balanceAfter` transfer could be easily mapped into a token balances table (for post-crescendo only).