### PR TITLE
An 5719/resume traces

### DIFF
--- a/models/evm/silver/core/silver_evm__traces.sql
+++ b/models/evm/silver/core/silver_evm__traces.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('bronze_evm__traces') }}
+-- depends_on: {{ ref('bronze_evm__FR_traces') }}
 
 {{ config (
     materialized = "incremental",

--- a/models/evm/silver/core/silver_evm__traces.sql
+++ b/models/evm/silver/core/silver_evm__traces.sql
@@ -36,8 +36,11 @@ WITH bronze_traces AS (
         WHERE DATA :result IS NOT NULL 
     {% endif %}
 
-),
+qualify(ROW_NUMBER() over (PARTITION BY block_number, tx_position
+ORDER BY
+    _inserted_timestamp DESC)) = 1
 
+),
 flatten_traces AS (
     SELECT
         block_number,

--- a/models/evm/silver/core/silver_evm__traces.sql
+++ b/models/evm/silver/core/silver_evm__traces.sql
@@ -6,41 +6,35 @@
     unique_key = "block_number",
     cluster_by = ['modified_timestamp::DATE','partition_key'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)",
-    enabled = false,
     tags = ['evm']
 ) }}
 
 
-WITH base AS (
+WITH bronze_traces AS (
+
         SELECT
             block_number,
             partition_key,
+            value:array_index::INT AS tx_position,
             DATA :result AS full_traces,
             _inserted_timestamp
         FROM 
-            {{ ref('bronze_evm__traces') }}
-    WHERE DATA :result IS NOT NULL 
+
     {% if is_incremental()%}
-    and _inserted_timestamp >= (
-        SELECT
-            COALESCE(MAX(_inserted_timestamp), '1900-01-01') _inserted_timestamp
-        FROM
-            {{ this }}
-    ) 
-{% endif %}
+        {{ ref('bronze_evm__traces') }}
+            WHERE 
+                DATA :result IS NOT NULL 
+            AND _inserted_timestamp >= (
+                SELECT
+                    COALESCE(MAX(_inserted_timestamp), '1900-01-01') _inserted_timestamp
+                FROM
+                    {{ this }}
+            ) 
+    {% else %}
+        {{ ref('bronze_evm__FR_traces') }}
+        WHERE DATA :result IS NOT NULL 
+    {% endif %}
 
-qualify(ROW_NUMBER() over (PARTITION BY block_number ORDER BY _inserted_timestamp DESC)) = 1
-),
-bronze_traces AS (
-
-select 
-    block_number,
-    partition_key,
-    index as tx_position,
-    value:result as full_traces,
-    _inserted_timestamp
-from base,
-lateral flatten (input=>full_traces)
 ),
 
 flatten_traces AS (

--- a/models/evm/streamline/realtime/streamline__get_evm_traces_realtime.sql
+++ b/models/evm/streamline/realtime/streamline__get_evm_traces_realtime.sql
@@ -10,7 +10,6 @@
         "sql_source" :"{{this.identifier}}",
         "exploded_key": tojson(["result"])}
     ),
-    enabled = false,
     tags = ['streamline_realtime_evm']
 ) }}
 

--- a/models/evm/streamline/realtime/streamline__get_evm_traces_realtime.sql
+++ b/models/evm/streamline/realtime/streamline__get_evm_traces_realtime.sql
@@ -5,7 +5,7 @@
         target = "{{this.schema}}.{{this.identifier}}",
         params ={ "external_table" :"evm_traces_v2",
         "sql_limit" :"25000",
-        "producer_batch_size" :"5000",
+        "producer_batch_size" :"2000",
         "worker_batch_size" :"1000",
         "sql_source" :"{{this.identifier}}",
         "exploded_key": tojson(["result"])}


### PR DESCRIPTION
`dbt run -m models/evm/silver/core/silver_evm__traces.sql --full-refresh`