### PR TITLE
add _utils to integration_test selector

### DIFF
--- a/selectors.yml
+++ b/selectors.yml
@@ -4,5 +4,5 @@ selectors:
     definition:
       union:
         - method: fqn
-          value: "livequery_models.deploy.core.*"
+          value: "livequery_models.deploy.core._utils"
         


### PR DESCRIPTION
- Reduces scope of `integration_tests` selector to only run `streamline udf api integration` tests

Example [error](https://github.com/FlipsideCrypto/flow-models/actions/runs/13000160880/job/36256975175#step:5:45)


Success running locally:

```
23:17:05  Concurrency: 12 threads (target='dev')
23:17:05  
23:17:05  1 of 1 START test test___utils_udf_introspect .................................. [RUN]
23:17:09  1 of 1 PASS test___utils_udf_introspect ........................................ [PASS in 3.76s]
23:17:09  
23:17:09  Running 2 on-run-end hooks
23:17:09  1 of 2 START hook: flow_models.on-run-end.0 .................................... [RUN]
23:17:09  1 of 2 OK hook: flow_models.on-run-end.0 ....................................... [OK in 0.00s]
23:17:09  2 of 2 START hook: livequery_models.on-run-end.0 ............................... [RUN]
23:17:09  2 of 2 OK hook: livequery_models.on-run-end.0 .................................. [OK in 0.00s]
23:17:09  
23:17:09  
23:17:09  Finished running 1 test, 5 hooks in 0 hours 0 minutes and 23.46 seconds (23.46s).
23:17:09  
23:17:09  Completed successfully
23:17:09  
23:17:09  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```