### PR TITLE
Modify Transaction Results

### DIFF
--- a/models/silver/core/silver__streamline_transaction_results.sql
+++ b/models/silver/core/silver__streamline_transaction_results.sql
@@ -33,7 +33,7 @@ FROM
 {% elif var('MANUAL_FIX', False) %}
     {{ ref('bronze__streamline_fr_transaction_results') }}
     WHERE 
-        _partition_by_block_id BETWEEN var('RANGE_START', 0) AND var('RANGE_END', 0)
+        _partition_by_block_id BETWEEN {{ var('RANGE_START', 0) }} AND {{ var('RANGE_END', 0) }}
 {% else %}
 
 {% if is_incremental() %}

--- a/models/silver/core/silver__streamline_transaction_results.sql
+++ b/models/silver/core/silver__streamline_transaction_results.sql
@@ -12,7 +12,7 @@
 SELECT
     block_number,
     id AS tx_id,
-    DATA: error_message :: STRING AS error_message,
+    DATA :error_message :: STRING AS error_message,
     DATA :events :: ARRAY AS events,
     DATA :status :: INT AS status,
     DATA :status_code :: INT AS status_code,
@@ -43,7 +43,7 @@ WHERE
     )
     -- AND _partition_by_block_id > 107700000 -- march 27th 2025
     -- AND _partition_by_block_id > 108000000 -- march 28th 2025
-    AND _partition_by_block_id > 108800000 -- april 5th 2025
+    -- AND _partition_by_block_id > 108800000 -- april 5th 2025
 {% else %}
     {{ ref('bronze__streamline_fr_transaction_results') }}
 {% endif %}

--- a/models/silver/core/silver__streamline_transaction_results.sql
+++ b/models/silver/core/silver__streamline_transaction_results.sql
@@ -30,6 +30,10 @@ FROM
         {{ ref('bronze__streamline_transaction_results_history') }}
         -- TODO need incremental logic of some sort probably (for those 5800 missing txs)
         -- where inserted timestamp >= max from this where network version = backfill version OR block range between root and end
+{% elif var('MANUAL_FIX', False) %}
+    {{ ref('bronze__streamline_fr_transaction_results') }}
+    WHERE 
+        _partition_by_block_id BETWEEN var('RANGE_START', 0) AND var('RANGE_END', 0)
 {% else %}
 
 {% if is_incremental() %}

--- a/models/silver/core/silver__streamline_transactions_final.sql
+++ b/models/silver/core/silver__streamline_transactions_final.sql
@@ -18,7 +18,7 @@
                     block_height
                 FROM """ ~ this ~ """
                 WHERE
-                    modified_timestamp >= SYSDATE() - INTERVAL '{{ var('RETRY_WINDOW', 7) }} days'
+                    modified_timestamp >= SYSDATE() - INTERVAL '""" ~ var('RETRY_WINDOW', 3) ~ """ days'
                     AND (
                         block_timestamp IS NULL
                         OR pending_result_response
@@ -43,7 +43,7 @@
                 )
                 OR -- re-run record if block comes in later than tx records
                 (
-                    modified_timestamp >= SYSDATE() - INTERVAL '3 days'
+                    modified_timestamp >= SYSDATE() - INTERVAL '""" ~ var('RETRY_WINDOW', 3) ~ """ days'
                     AND
                     tx_id IN (
                         SELECT
@@ -81,7 +81,7 @@ tx_results AS (
 
 {% if is_incremental() %}
 WHERE
-    modified_timestamp >= SYSDATE() - INTERVAL '3 days'
+    modified_timestamp >= SYSDATE() - INTERVAL '{{ var('RETRY_WINDOW', 3) }} days'
     AND tx_id IN (
         SELECT
             DISTINCT tx_id

--- a/models/silver/core/silver__streamline_transactions_final.sql
+++ b/models/silver/core/silver__streamline_transactions_final.sql
@@ -18,7 +18,7 @@
                     block_height
                 FROM """ ~ this ~ """
                 WHERE
-                    modified_timestamp >= SYSDATE() - INTERVAL '7 days'
+                    modified_timestamp >= SYSDATE() - INTERVAL '{{ var('RETRY_WINDOW', 7) }} days'
                     AND (
                         block_timestamp IS NULL
                         OR pending_result_response

--- a/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
+++ b/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
@@ -27,7 +27,7 @@ WHERE
         ),
         '1900-01-01' :: timestamp_ntz
     )
-    AND _partition_by_block_id = 108800000
+    -- AND _partition_by_block_id > 108800000
     -- id NOT IN (
     --     'f31f601728b59a0411b104e6795eb18e32c9b1bea3e52ea1d28a801ed5ceb009',
     --     'b68b81b7a2ec9fb4e3789f871f95084ba4fdd9b46bb6c7029efa578a69dba432'

--- a/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
+++ b/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
@@ -27,7 +27,6 @@ WHERE
         ),
         '1900-01-01' :: timestamp_ntz
     )
-    -- AND _partition_by_block_id > 108800000
     -- id NOT IN (
     --     'f31f601728b59a0411b104e6795eb18e32c9b1bea3e52ea1d28a801ed5ceb009',
     --     'b68b81b7a2ec9fb4e3789f871f95084ba4fdd9b46bb6c7029efa578a69dba432'

--- a/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
+++ b/models/streamline/core/complete/streamline__complete_get_transaction_results.sql
@@ -10,7 +10,6 @@
 
 SELECT
     id,
-    DATA,
     block_number,
     _partition_by_block_id,
     _inserted_timestamp
@@ -28,7 +27,7 @@ WHERE
         ),
         '1900-01-01' :: timestamp_ntz
     )
-    AND _partition_by_block_id > 108800000
+    AND _partition_by_block_id = 108800000
     -- id NOT IN (
     --     'f31f601728b59a0411b104e6795eb18e32c9b1bea3e52ea1d28a801ed5ceb009',
     --     'b68b81b7a2ec9fb4e3789f871f95084ba4fdd9b46bb6c7029efa578a69dba432'

--- a/models/streamline/core/complete/streamline__complete_get_transactions.sql
+++ b/models/streamline/core/complete/streamline__complete_get_transactions.sql
@@ -10,7 +10,6 @@
 
 SELECT
     id,
-    data,
     block_number,
     _partition_by_block_id,
     _inserted_timestamp

--- a/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
+++ b/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
@@ -68,8 +68,6 @@ SELECT
     ) AS request
 FROM
     transactions_to_ingest
-WHERE
-    block_height > 108800000
     -- transaction_id NOT IN (
     --     'f31f601728b59a0411b104e6795eb18e32c9b1bea3e52ea1d28a801ed5ceb009',
     --     'b68b81b7a2ec9fb4e3789f871f95084ba4fdd9b46bb6c7029efa578a69dba432'

--- a/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
+++ b/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
@@ -68,9 +68,6 @@ SELECT
     ) AS request
 FROM
     transactions_to_ingest
-    -- transaction_id NOT IN (
-    --     'f31f601728b59a0411b104e6795eb18e32c9b1bea3e52ea1d28a801ed5ceb009',
-    --     'b68b81b7a2ec9fb4e3789f871f95084ba4fdd9b46bb6c7029efa578a69dba432'
-    -- )
+
 ORDER BY
     block_height DESC


### PR DESCRIPTION
 - Deletes `DATA` from tx and txres complete models as it is not necessary for the realtime workflow. Can drop the col to save space.
 - Adds a `MANUAL_FIX` clause to silver transaction results to rerun the gap range(s)
 - Adds a `RETRY_WINDOW` var to transactions final as the initial error was >7d ago.


Example (can modify range to the gap over 3/28-29).
`dbt run -s silver__streamline_transaction_results --vars '{"MANUAL_FIX": True, "RANGE_START":108800000, "RANGE_END": 108800000}'`
 - [Run result](https://app.snowflake.com/zsniary/exa10207/#/compute/history/queries/01bb89f0-0414-a5b1-3d4f-83031ebbe03b/detail) of this range, which otherwise raises an overflow error.  

And then `dbt run -s silver__streamline_transactions_final --vars '{"RETRY_WINDOW": 14}'`

Note: the external table `streamline.flow_dev.transaction_results` is configured per the changes in this [PR](https://github.com/FlipsideCrypto/streamline-snowflake/pull/245) with the location set to the prod bucket.