### PR TITLE
set lookback block height

### DIFF
--- a/.github/workflows/dbt_run_streamline_blocks.yml
+++ b/.github/workflows/dbt_run_streamline_blocks.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run DBT Realtime
         run: |
-          dbt run -s 1+streamline__get_blocks_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
+          dbt run -s 1+streamline__get_blocks_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": False}'

--- a/.github/workflows/dbt_run_streamline_collections.yml
+++ b/.github/workflows/dbt_run_streamline_collections.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run DBT Realtime
         run: |
-          dbt run -s 1+streamline__get_collections_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
+          dbt run -s 1+streamline__get_collections_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": False}'

--- a/.github/workflows/dbt_run_streamline_transaction_results.yml
+++ b/.github/workflows/dbt_run_streamline_transaction_results.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run DBT Realtime
         run: |
-          dbt run -s 1+streamline__get_transaction_results_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True, "producer_batch_size": 60000, "worker_batch_size": 2000}'
+          dbt run -s 1+streamline__get_transaction_results_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": False, "producer_batch_size": 60000, "worker_batch_size": 2000}'

--- a/.github/workflows/dbt_run_streamline_transactions.yml
+++ b/.github/workflows/dbt_run_streamline_transactions.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run DBT Realtime
         run: |
-          dbt run -s 1+streamline__get_transactions_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": True}'
+          dbt run -s 1+streamline__get_transactions_realtime --vars '{"STREAMLINE_INVOKE_STREAMS": True, "STREAMLINE_RUN_HISTORY": False}'

--- a/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
+++ b/models/streamline/core/realtime/streamline__get_transaction_results_realtime.sql
@@ -7,12 +7,17 @@
     tags = ['streamline_realtime']
 ) }}
 
-WITH last_3_days AS ({% if var('STREAMLINE_RUN_HISTORY') %}
+WITH last_3_days AS (
+{% if var('STREAMLINE_RUN_HISTORY') %}
 
     SELECT
         MAX(root_height) AS block_height
     FROM
         {{ ref('seeds__network_version') }}
+    {% elif var('STREAMLINE_BACKFILL', False) %}
+    SELECT
+        107600000 AS block_height
+    
     {% else %}
     SELECT
         MAX(block_height) - 210000 AS block_height


### PR DESCRIPTION
Sets a starting block height to backfill missing txs starting in late March.
Run with `dbt run -s streamline__get_transaction_results_realtime --vars '{"STREAMLINE_BACKFILL": True, "STREAMLINE_INVOKE_STREAMS": True, "sql_limit": 700000}'`