### PR TITLE
remove block filter on bridge recency

### DIFF
--- a/models/gold/defi/defi__ez_bridge_activity.yml
+++ b/models/gold/defi/defi__ez_bridge_activity.yml
@@ -18,7 +18,6 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 3
-              where: block_height >= 55114467
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ

--- a/models/gold/defi/defi__fact_bridge_activity.yml
+++ b/models/gold/defi/defi__fact_bridge_activity.yml
@@ -18,7 +18,6 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 3
-              where: block_height >= 55114467
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - TIMESTAMP_NTZ


### PR DESCRIPTION
Stargate bridge is on EVM so `block_height ` filter for recency doesn't correctly apply to those tx's